### PR TITLE
Support github workflow and run travis for all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ branches:
     only:
         - master
         - develop
+        - /.*/
 
 env:
     global:


### PR DESCRIPTION

## Support travis for all branches

For example, I have pulled requests to @AurevoirXavier's fork last night, but there is no ci supports, and we can not find out whether the tests are passed or not because our `travis.yml` says it only supports `develop` and `master`, other branches also deserve this right~
