### PR TITLE
ci: free the nightly version of Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-rust: nightly-2020-02-07
+rust: nightly
 
 branches:
     only:
@@ -13,7 +13,7 @@ env:
 before_install:
     # Check how much space we've got on this machine.
     - df -h
-    - rustup target add wasm32-unknown-unknown --toolchain nightly-2020-02-07
+    - rustup target add wasm32-unknown-unknown --toolchain nightly
 
 
 jobs:
@@ -22,16 +22,16 @@ jobs:
       script: .maintain/ci/fmt_script.sh
 
     - stage: Build
-      env: RUST_TOOLCHAIN=nightly-2020-02-07 TARGET=native
+      env: RUST_TOOLCHAIN=nightly TARGET=native
       script: .maintain/ci/build_script.sh
 
     - stage: Build
-      env: RUST_TOOLCHAIN=nightly-2020-02-07 TARGET=wasm
+      env: RUST_TOOLCHAIN=nightly TARGET=wasm
       script: .maintain/ci/build_script.sh
 
     # over the time limitation, so we comment this
     # - stage: Overall Test 
-    #   env: RUST_TOOLCHAIN=nightly-2020-02-07 TARGET=native
+    #   env: RUST_TOOLCHAIN=nightly TARGET=native
     #   script: .maintain/ci/test_script.sh
 
 after_script:


### PR DESCRIPTION
Due to #273, we are freezing the nightly rust version to shrink the hinder of developing.
The issue may not exist now, so we free the nightly version.