### PR TITLE
Related to #447, try fixing TargetedFeeAdjustment

### DIFF
--- a/runtime/common/src/impls.rs
+++ b/runtime/common/src/impls.rs
@@ -141,7 +141,7 @@ impl<T: Get<Perquintill>, R: frame_system::Trait> Convert<Fixed128, Fixed128>
 				.saturating_add(Fixed128::from_natural(1))
 				.saturating_mul(Fixed128::from_natural(1).saturating_add(excess))
 				.max(Fixed128::from_natural(0))
-				.saturating_sub(Fixed128::from_natural(-1))
+				.saturating_sub(Fixed128::from_natural(1))
 		} else {
 			// Defensive-only: first_term > second_term. Safe subtraction.
 			let negative = first_term.saturating_sub(second_term);
@@ -155,7 +155,7 @@ impl<T: Get<Perquintill>, R: frame_system::Trait> Convert<Fixed128, Fixed128>
 				.saturating_add(Fixed128::from_natural(1))
 				.saturating_mul(Fixed128::from_natural(1).saturating_sub(negative))
 				.max(Fixed128::from_natural(0))
-				.saturating_sub(Fixed128::from_natural(-1))
+				.saturating_sub(Fixed128::from_natural(1))
 		}
 	}
 }


### PR DESCRIPTION
Might be better to submit a PR to substrate transaction-payment pallet if issue #447 is confirmed, by replacing ```saturated_multiply_accumulate``` with ```saturating_mul ```, and fix the TargetedFeeAdjustment using op 

```* (1+v(s−s∗)+v2(s−s∗)2/2)```