### PR TITLE
GitHub Actions builds docker image.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,3 +19,7 @@ indent_style=space
 indent_size=2
 indent_style=space
 tab_width=8
+
+[Dockerfile*]
+indent_size=2
+indent_style=space

--- a/.editorconfig
+++ b/.editorconfig
@@ -21,5 +21,5 @@ indent_style=space
 tab_width=8
 
 [Dockerfile*]
-indent_size=2
+indent_size=4
 indent_style=space

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ on:
     tags: ["*"]
 
 jobs:
-  build-and-test:
-    name: Build docker image
+  build-docker-image:
+    name: Build Docker image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+on:
+  push:
+    tags: ["*"]
+    branches: ["feature/github-actions-build-docker-image"]
+
+jobs:
+  build-and-test:
+    name: Build docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          repository: itering/actions
+          path: .github/actions
+          persist-credentials: false
+          ssh-key: "${{ secrets.ITERING_ACTIONS_DEPLOY_KEY }}"
+
+      - name: Docker login
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.QUAY_IO_BOT_USERNAME }}
+          password: ${{ secrets.QUAY_IO_BOT_PASSWORD }}
+          registry: quay.io
+
+      - uses: ./.github/actions/docker-build-deploy
+        with:
+          deploy_phase: production
+          docker_registry: quay.io
+          trigger_token: ${{ secrets.ITERING_DEPLOYMENT_TRIGGER_TOKEN }}
+          trigger_endpoint: ${{ secrets.ITERING_DEPLOYMENT_TRIGGER_ENDPOINT }}
+          docker_build_options: -f .maintain/docker/Dockerfile
+          skip_deploy: true # for now
+
+      - uses: ./.github/actions/dingtalk-notify
+        if: failure() && (github.event_name == 'pull_request' && github.event.pull_request.draft == false || github.event_name != 'pull_request')
+        with:
+          dingtalk_bot_token: ${{ secrets.DINGTALK_BOT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: Release
 on:
   push:
     tags: ["*"]
-    branches: ["feature/github-actions-build-docker-image"]
 
 jobs:
   build-and-test:

--- a/.maintain/docker/Dockerfile
+++ b/.maintain/docker/Dockerfile
@@ -7,6 +7,12 @@ FROM rust:1 as builder
 ARG RUST_TOOLCHAIN=nightly-2020-10-06
 ENV CARGO_TERM_COLOR=always
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        clang \
+        libclang-dev \
+        cmake \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN rustup update \
     && rustup install ${RUST_TOOLCHAIN} \
     && rustup default ${RUST_TOOLCHAIN} \

--- a/.maintain/docker/Dockerfile
+++ b/.maintain/docker/Dockerfile
@@ -1,20 +1,34 @@
-FROM iteringops/darwinia-builder:latest as builder
+##
+# Builder
+##
 
-RUN rustup update && rustup default nightly
+FROM rust:1 as builder
 
-COPY . /source
-WORKDIR /source
+ARG RUST_TOOLCHAIN=nightly-2020-10-06
+ENV CARGO_TERM_COLOR=always
 
-ENV TERM="xterm-256color"
+RUN rustup update \
+    && rustup install ${RUST_TOOLCHAIN} \
+    && rustup default ${RUST_TOOLCHAIN} \
+    && rustup target add wasm32-unknown-unknown --toolchain ${RUST_TOOLCHAIN}
+
+WORKDIR /src
+COPY . .
 
 RUN cargo build --release
 
+##
+# Final stage
+##
+
 FROM debian:stable-slim
 
-RUN apt-get update && apt-get -y install openssl && apt-get clean
-COPY --from=builder /source/target/release/darwinia /usr/local/bin/.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        openssl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /src/target/release/darwinia /usr/local/bin/
 
 EXPOSE 30333 9933 9944
-VOLUME ["/data"]
 
 ENTRYPOINT [ "/usr/local/bin/darwinia" ]

--- a/.maintain/docker/Dockerfile
+++ b/.maintain/docker/Dockerfile
@@ -13,10 +13,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         cmake \
     && rm -rf /var/lib/apt/lists/*
 
-RUN rustup update \
-    && rustup install ${RUST_TOOLCHAIN} \
-    && rustup default ${RUST_TOOLCHAIN} \
-    && rustup target add wasm32-unknown-unknown --toolchain ${RUST_TOOLCHAIN}
+RUN rustup default ${RUST_TOOLCHAIN} \
+    && rustup target add wasm32-unknown-unknown
 
 WORKDIR /src
 COPY . .


### PR DESCRIPTION
Due to the strict resource limit of DockerHub's CI, migrate the docker image build process to GitHub Actions. Also, Docker announced the rate limits per IP starting on 1st Nov. This might impact users like me who use the Docker image running Darwinia. I'd like to publish the image on [quay.io](https://quay.io) which is the provider we've already used in other projects like [darwinia-network/shadow](https://quay.io/repository/darwinia-network/apps) and [darwinia-network/apps](https://quay.io/repository/darwinia-network/apps).

The DockerHub build hasn't been removed. After the build on GitHub Actions gets stable, I'll choose a time to bring down the automated builds on Docker Hub.

BTW, this PR removed the dependency of the legacy builder image `iteringops/darwinia-builder`, cc @freehere107 think you might need to know this. If there's no other repo requiring the image, it can be deprecated at any time (I don't have the org `iteringops` permission on DockerHub).