### PR TITLE
Tag All Deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,9 +170,9 @@ checksum = "43759f68cc29a37659a6b7a48a49674e03a888b6d41f36f4204c36d0d09a51de"
 [[package]]
 name = "array-bytes"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
- "sp-std 2.0.0",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
@@ -928,11 +928,11 @@ dependencies = [
  "darwinia-treasury",
  "ethereum-primitives",
  "frame-executive",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "frame-system-rpc-runtime-api",
  "pallet-authority-discovery",
- "pallet-authorship",
+ "pallet-authorship 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "pallet-babe",
  "pallet-collective",
  "pallet-grandpa",
@@ -946,29 +946,29 @@ dependencies = [
  "pallet-randomness-collective-flip",
  "pallet-recovery",
  "pallet-scheduler",
- "pallet-session",
+ "pallet-session 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "pallet-society",
  "pallet-sudo",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-utility",
  "parity-scale-codec 1.3.6",
  "serde",
  "smallvec 1.6.1",
- "sp-api",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "sp-authority-discovery",
- "sp-block-builder",
- "sp-consensus-babe",
- "sp-core",
- "sp-inherents",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-staking",
- "sp-std 2.0.0",
- "sp-transaction-pool",
- "sp-version",
+ "sp-block-builder 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-offchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-session 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-staking 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "static_assertions",
  "substrate-wasm-builder-runner",
 ]
@@ -1253,60 +1253,60 @@ dependencies = [
 [[package]]
 name = "darwinia-balances"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "darwinia-balances-rpc-runtime-api",
  "darwinia-support",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-balances-rpc"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "darwinia-balances-rpc-runtime-api",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "parity-scale-codec 1.3.6",
- "sp-api",
- "sp-blockchain",
- "sp-runtime",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-balances-rpc-runtime-api"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "darwinia-support",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-api",
- "sp-runtime",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-claims"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "array-bytes 1.3.0",
  "darwinia-support",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "parity-scale-codec 1.3.6",
  "serde",
  "serde_json",
- "sp-io",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
@@ -1316,15 +1316,15 @@ dependencies = [
  "darwinia-cli 1.3.0",
  "darwinia-service",
  "log",
- "sc-cli",
- "sc-client-api",
- "sc-executor",
- "sc-network",
- "sc-service",
- "sc-tracing",
+ "sc-cli 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-executor 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-network 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-service 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "serde",
- "sp-core",
- "sp-trie",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-trie 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "structopt",
  "substrate-browser-utils",
  "substrate-build-script-utils",
@@ -1336,12 +1336,12 @@ dependencies = [
 [[package]]
 name = "darwinia-cli"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
- "sc-cli",
- "sc-client-api",
- "sc-service",
- "sc-tracing",
+ "sc-cli 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-service 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "serde",
  "toml",
 ]
@@ -1349,81 +1349,81 @@ dependencies = [
 [[package]]
 name = "darwinia-crab-backing"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-runtime",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-crab-issuing"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-runtime",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-democracy"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "darwinia-support",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-io",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-elections-phragmen"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "darwinia-support",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "parity-scale-codec 1.3.6",
  "serde",
  "sp-npos-elections",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-ethereum-backing"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "array-bytes 1.3.0",
  "darwinia-relay-primitives",
  "darwinia-support",
  "ethabi",
  "ethereum-primitives",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "parity-scale-codec 1.3.6",
  "serde",
  "serde_json",
- "sp-io",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-ethereum-relay"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "array-bytes 1.3.0",
  "blake2-rfc",
@@ -1433,112 +1433,112 @@ dependencies = [
  "darwinia-support",
  "ethereum-primitives",
  "ethereum-types",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "parity-scale-codec 1.3.6",
  "rlp 0.4.4",
  "serde",
  "serde_json",
- "sp-core",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-header-mmr"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "ckb-merkle-mountain-range",
  "darwinia-header-mmr-rpc-runtime-api",
  "darwinia-relay-primitives",
  "darwinia-support",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-header-mmr-rpc"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "darwinia-header-mmr-rpc-runtime-api",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "parity-scale-codec 1.3.6",
- "sp-api",
- "sp-blockchain",
- "sp-runtime",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-header-mmr-rpc-runtime-api"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "darwinia-support",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-api",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-primitives"
 version = "0.9.5"
 dependencies = [
- "frame-system",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
- "sp-application-crypto",
- "sp-core",
- "sp-runtime",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "darwinia-relay-authorities"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "darwinia-relay-primitives",
  "darwinia-support",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-relay-primitives"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
- "frame-support",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "parity-scale-codec 1.3.6",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-relayer-game"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "darwinia-relay-primitives",
  "darwinia-support",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
@@ -1552,23 +1552,23 @@ dependencies = [
  "jsonrpc-core",
  "pallet-transaction-payment-rpc",
  "parity-scale-codec 1.3.6",
- "sc-chain-spec",
- "sc-client-api",
- "sc-consensus-babe",
+ "sc-chain-spec 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-consensus-babe 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "sc-consensus-babe-rpc",
- "sc-consensus-epochs",
- "sc-finality-grandpa",
+ "sc-consensus-epochs 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-finality-grandpa 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "sc-finality-grandpa-rpc",
- "sc-rpc",
+ "sc-rpc 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "sc-sync-state-rpc",
- "sp-api",
- "sp-block-builder",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-babe",
- "sp-keystore",
- "sp-runtime",
- "sp-transaction-pool",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-block-builder 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "substrate-frame-rpc-system",
 ]
 
@@ -1599,11 +1599,11 @@ dependencies = [
  "darwinia-vesting",
  "ethereum-primitives",
  "frame-executive",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "frame-system-rpc-runtime-api",
  "pallet-authority-discovery",
- "pallet-authorship",
+ "pallet-authorship 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "pallet-babe",
  "pallet-collective",
  "pallet-grandpa",
@@ -1616,10 +1616,10 @@ dependencies = [
  "pallet-randomness-collective-flip",
  "pallet-recovery",
  "pallet-scheduler",
- "pallet-session",
+ "pallet-session 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "pallet-society",
  "pallet-sudo",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-utility",
@@ -1627,19 +1627,19 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec 1.6.1",
- "sp-api",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "sp-authority-discovery",
- "sp-block-builder",
- "sp-consensus-babe",
- "sp-core",
- "sp-inherents",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-staking",
- "sp-std 2.0.0",
- "sp-transaction-pool",
- "sp-version",
+ "sp-block-builder 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-offchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-session 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-staking 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "static_assertions",
  "substrate-wasm-builder-runner",
 ]
@@ -1652,13 +1652,13 @@ dependencies = [
  "darwinia-primitives",
  "darwinia-staking",
  "darwinia-support",
- "frame-support",
- "frame-system",
- "pallet-authorship",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "pallet-authorship 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "pallet-transaction-payment",
  "parity-scale-codec 1.3.6",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "static_assertions",
 ]
 
@@ -1682,56 +1682,56 @@ dependencies = [
  "parity-scale-codec 1.3.6",
  "sc-authority-discovery",
  "sc-basic-authorship",
- "sc-chain-spec",
- "sc-client-api",
- "sc-client-db",
- "sc-consensus",
- "sc-consensus-babe",
- "sc-executor",
- "sc-finality-grandpa",
- "sc-network",
- "sc-service",
- "sc-telemetry",
- "sc-transaction-pool",
+ "sc-chain-spec 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-client-db 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-consensus-babe 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-executor 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-finality-grandpa 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-network 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-service 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-telemetry 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "sp-authority-discovery",
- "sp-block-builder",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-babe",
- "sp-core",
- "sp-finality-grandpa",
- "sp-inherents",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-transaction-pool",
- "sp-trie",
- "substrate-prometheus-endpoint",
+ "sp-block-builder 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-finality-grandpa 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-offchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-session 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-trie 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "darwinia-staking"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "darwinia-staking-rpc-runtime-api",
  "darwinia-support",
- "frame-support",
- "frame-system",
- "pallet-authorship",
- "pallet-session",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "pallet-authorship 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "pallet-session 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
+ "sp-arithmetic 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "sp-npos-elections",
- "sp-runtime",
- "sp-staking",
- "sp-std 2.0.0",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-staking 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "static_assertions",
  "substrate-fixed",
 ]
@@ -1739,83 +1739,83 @@ dependencies = [
 [[package]]
 name = "darwinia-staking-rpc"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "darwinia-staking-rpc-runtime-api",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "parity-scale-codec 1.3.6",
- "sp-api",
- "sp-blockchain",
- "sp-runtime",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-staking-rpc-runtime-api"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "darwinia-support",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-api",
- "sp-runtime",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-support"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "ethereum-primitives",
- "frame-support",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "impl-trait-for-tuples 0.2.1",
  "num-traits",
  "parity-scale-codec 1.3.6",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-treasury"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "darwinia-support",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-tron-backing"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-runtime",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "darwinia-vesting"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "darwinia-support",
  "enumflags2",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
@@ -2051,7 +2051,7 @@ dependencies = [
 [[package]]
 name = "ethereum-primitives"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "array-bytes 1.3.0",
  "ethash",
@@ -2067,9 +2067,9 @@ dependencies = [
  "rlp 0.4.4",
  "rlp-derive",
  "serde",
- "sp-io",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
@@ -2229,6 +2229,14 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "parity-scale-codec 1.3.6",
+]
+
+[[package]]
+name = "fork-tree"
+version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "parity-scale-codec 1.3.6",
@@ -2247,35 +2255,64 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "linregress",
  "parity-scale-codec 1.3.6",
  "paste",
- "sp-api",
- "sp-io",
- "sp-runtime",
- "sp-runtime-interface",
- "sp-std 2.0.0",
- "sp-storage",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-storage 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "frame-benchmarking"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "linregress",
+ "parity-scale-codec 1.3.6",
+ "paste",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-storage 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std 2.0.0",
- "sp-tracing",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "frame-metadata"
+version = "12.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "parity-scale-codec 1.3.6",
+ "serde",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -2285,8 +2322,33 @@ source = "git+https://github.com/darwinia-network/substrate.git?branch=common-li
 dependencies = [
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-core",
- "sp-std 2.0.0",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "frame-support"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "bitmask",
+ "frame-metadata 12.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-support-procedural 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "impl-trait-for-tuples 0.1.3",
+ "log",
+ "once_cell 1.5.2",
+ "parity-scale-codec 1.3.6",
+ "paste",
+ "serde",
+ "smallvec 1.6.1",
+ "sp-arithmetic 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -2295,8 +2357,8 @@ version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "bitmask",
- "frame-metadata",
- "frame-support-procedural",
+ "frame-metadata 12.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-support-procedural 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "impl-trait-for-tuples 0.1.3",
  "log",
  "once_cell 1.5.2",
@@ -2304,14 +2366,25 @@ dependencies = [
  "paste",
  "serde",
  "smallvec 1.6.1",
- "sp-arithmetic",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
- "sp-std 2.0.0",
- "sp-tracing",
+ "sp-arithmetic 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "frame-support-procedural"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "frame-support-procedural-tools 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2319,7 +2392,19 @@ name = "frame-support-procedural"
 version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support-procedural-tools",
+ "frame-support-procedural-tools 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "frame-support-procedural-tools"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -2330,8 +2415,18 @@ name = "frame-support-procedural-tools"
 version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support-procedural-tools-derive",
+ "frame-support-procedural-tools-derive 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "frame-support-procedural-tools-derive"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -2350,26 +2445,42 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "impl-trait-for-tuples 0.1.3",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std 2.0.0",
- "sp-version",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "frame-system"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "impl-trait-for-tuples 0.1.3",
+ "parity-scale-codec 1.3.6",
+ "serde",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "parity-scale-codec 1.3.6",
- "sp-api",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -4139,12 +4250,12 @@ checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 [[package]]
 name = "merkle-patricia-trie"
 version = "1.3.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=master#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=1.3.3#3a7f1ec93aecf4bced73e769cc9138db309fa29e"
 dependencies = [
  "hashbrown 0.9.1",
  "keccak-hash",
  "rlp 0.4.4",
- "sp-std 2.0.0",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
@@ -4509,17 +4620,32 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
- "frame-system",
- "pallet-session",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "pallet-session 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-application-crypto",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "sp-authority-discovery",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "pallet-authorship"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "impl-trait-for-tuples 0.1.3",
+ "parity-scale-codec 1.3.6",
+ "sp-authorship 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -4527,242 +4653,262 @@ name = "pallet-authorship"
 version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "impl-trait-for-tuples 0.1.3",
  "parity-scale-codec 1.3.6",
- "sp-authorship",
- "sp-inherents",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-authorship 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "pallet-babe"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "pallet-authorship",
- "pallet-session",
- "pallet-timestamp",
+ "frame-benchmarking 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "pallet-authorship 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "pallet-session 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "pallet-timestamp 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-application-crypto",
- "sp-consensus-babe",
- "sp-consensus-vrf",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
- "sp-session",
- "sp-staking",
- "sp-std 2.0.0",
- "sp-timestamp",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus-vrf 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-session 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-staking 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-timestamp 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "pallet-balances"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "pallet-collective"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "pallet-authorship",
- "pallet-session",
+ "frame-benchmarking 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "pallet-authorship 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "pallet-session 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-application-crypto",
- "sp-core",
- "sp-finality-grandpa",
- "sp-runtime",
- "sp-session",
- "sp-staking",
- "sp-std 2.0.0",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-finality-grandpa 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-session 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-staking 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "pallet-identity"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "enumflags2",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-io",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
- "frame-system",
- "pallet-authorship",
- "pallet-session",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "pallet-authorship 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "pallet-session 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-application-crypto",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-staking",
- "sp-std 2.0.0",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-staking 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "pallet-indices"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-core",
- "sp-io",
- "sp-keyring",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-keyring 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "pallet-membership"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-io",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "pallet-offences"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "pallet-balances",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-runtime",
- "sp-staking",
- "sp-std 2.0.0",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-staking 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "pallet-proxy"
 version = "2.0.1"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "safe-mix",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "enumflags2",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-io",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-io",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "pallet-session"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "impl-trait-for-tuples 0.1.3",
+ "pallet-timestamp 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "parity-scale-codec 1.3.6",
+ "serde",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-session 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-staking 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-trie 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -4770,47 +4916,64 @@ name = "pallet-session"
 version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "impl-trait-for-tuples 0.1.3",
- "pallet-timestamp",
+ "pallet-timestamp 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-session",
- "sp-staking",
- "sp-std 2.0.0",
- "sp-trie",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-session 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-staking 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-trie 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "pallet-society"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "rand_chacha 0.2.2",
  "serde",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-io",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "pallet-timestamp"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "frame-benchmarking 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "impl-trait-for-tuples 0.1.3",
+ "parity-scale-codec 1.3.6",
+ "serde",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-timestamp 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -4818,39 +4981,39 @@ name = "pallet-timestamp"
 version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "impl-trait-for-tuples 0.1.3",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-inherents",
- "sp-runtime",
- "sp-std 2.0.0",
- "sp-timestamp",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-timestamp 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec 1.3.6",
  "serde",
  "smallvec 1.6.1",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4858,39 +5021,39 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-api",
- "sp-blockchain",
- "sp-core",
- "sp-rpc",
- "sp-runtime",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-rpc 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-api",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "pallet-utility"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "frame-system 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -6081,7 +6244,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
@@ -6095,41 +6258,58 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sc-client-api",
- "sc-keystore",
- "sc-network",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-keystore 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-network 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "serde_json",
- "sp-api",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "sp-authority-discovery",
- "sp-blockchain",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
- "substrate-prometheus-endpoint",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec 1.3.6",
- "sc-block-builder",
- "sc-client-api",
+ "sc-block-builder 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "sc-proposer-metrics",
- "sc-telemetry",
- "sp-api",
- "sp-blockchain",
- "sp-consensus",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-transaction-pool",
- "substrate-prometheus-endpoint",
+ "sc-telemetry 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "tokio-executor 0.2.0-alpha.6",
+]
+
+[[package]]
+name = "sc-block-builder"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "parity-scale-codec 1.3.6",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-block-builder 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -6138,15 +6318,36 @@ version = "0.8.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "parity-scale-codec 1.3.6",
- "sc-client-api",
- "sp-api",
- "sp-block-builder",
- "sp-blockchain",
- "sp-consensus",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-block-builder 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sc-chain-spec"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "impl-trait-for-tuples 0.1.3",
+ "parity-scale-codec 1.3.6",
+ "sc-chain-spec-derive 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-consensus-babe 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-consensus-epochs 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-finality-grandpa 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-network 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-telemetry 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "serde",
+ "serde_json",
+ "sp-chain-spec 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -6156,18 +6357,29 @@ source = "git+https://github.com/darwinia-network/substrate.git?branch=common-li
 dependencies = [
  "impl-trait-for-tuples 0.1.3",
  "parity-scale-codec 1.3.6",
- "sc-chain-spec-derive",
- "sc-consensus-babe",
- "sc-consensus-epochs",
- "sc-finality-grandpa",
- "sc-network",
- "sc-telemetry",
+ "sc-chain-spec-derive 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-consensus-babe 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-consensus-epochs 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-finality-grandpa 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-network 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-telemetry 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "serde",
  "serde_json",
- "sp-chain-spec",
- "sp-consensus-babe",
- "sp-core",
- "sp-runtime",
+ "sp-chain-spec 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sc-chain-spec-derive"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -6179,6 +6391,50 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sc-cli"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "ansi_term 0.12.1",
+ "atty",
+ "bip39",
+ "chrono",
+ "fdlimit",
+ "futures 0.3.8",
+ "hex",
+ "libp2p",
+ "log",
+ "names",
+ "parity-scale-codec 1.3.6",
+ "rand 0.7.3",
+ "regex",
+ "rpassword",
+ "sc-cli-proc-macro 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-keystore 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-network 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-service 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-telemetry 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "serde",
+ "serde_json",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-keyring 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "structopt",
+ "thiserror",
+ "tokio 0.2.25",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -6200,23 +6456,23 @@ dependencies = [
  "rand 0.7.3",
  "regex",
  "rpassword",
- "sc-cli-proc-macro",
- "sc-client-api",
- "sc-keystore",
- "sc-network",
- "sc-service",
- "sc-telemetry",
- "sc-tracing",
+ "sc-cli-proc-macro 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-keystore 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-network 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-service 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-telemetry 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "serde",
  "serde_json",
- "sp-blockchain",
- "sp-core",
- "sp-keyring",
- "sp-keystore",
- "sp-panic-handler",
- "sp-runtime",
- "sp-utils",
- "sp-version",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-keyring 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "structopt",
  "thiserror",
  "tokio 0.2.25",
@@ -6228,12 +6484,60 @@ dependencies = [
 [[package]]
 name = "sc-cli-proc-macro"
 version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sc-cli-proc-macro"
+version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sc-client-api"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "derive_more",
+ "fnv",
+ "futures 0.3.8",
+ "hash-db",
+ "hex-literal",
+ "kvdb",
+ "lazy_static",
+ "log",
+ "parity-scale-codec 1.3.6",
+ "parking_lot 0.10.2",
+ "sc-executor 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-telemetry 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-database 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-keyring 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-storage 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-trie 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -6251,26 +6555,56 @@ dependencies = [
  "log",
  "parity-scale-codec 1.3.6",
  "parking_lot 0.10.2",
- "sc-executor",
- "sc-telemetry",
- "sp-api",
- "sp-blockchain",
- "sp-consensus",
- "sp-core",
- "sp-database",
- "sp-externalities",
- "sp-inherents",
- "sp-keyring",
- "sp-keystore",
- "sp-runtime",
- "sp-state-machine",
- "sp-std 2.0.0",
- "sp-storage",
- "sp-transaction-pool",
- "sp-trie",
- "sp-utils",
- "sp-version",
- "substrate-prometheus-endpoint",
+ "sc-executor 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-telemetry 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-database 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-keyring 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-storage 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-trie 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sc-client-db"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "blake2-rfc",
+ "hash-db",
+ "kvdb",
+ "kvdb-memorydb",
+ "kvdb-rocksdb",
+ "linked-hash-map",
+ "log",
+ "parity-db",
+ "parity-scale-codec 1.3.6",
+ "parity-util-mem",
+ "parking_lot 0.10.2",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-executor 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-state-db 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-database 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-trie 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -6289,18 +6623,29 @@ dependencies = [
  "parity-scale-codec 1.3.6",
  "parity-util-mem",
  "parking_lot 0.10.2",
- "sc-client-api",
- "sc-executor",
- "sc-state-db",
- "sp-arithmetic",
- "sp-blockchain",
- "sp-consensus",
- "sp-core",
- "sp-database",
- "sp-runtime",
- "sp-state-machine",
- "sp-trie",
- "substrate-prometheus-endpoint",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-executor 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-state-db 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-database 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-trie 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sc-consensus"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -6308,19 +6653,19 @@ name = "sc-consensus"
 version = "0.8.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "sc-client-api",
- "sp-blockchain",
- "sp-consensus",
- "sp-runtime",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "derive_more",
- "fork-tree",
+ "fork-tree 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "futures 0.3.8",
  "futures-timer 3.0.2",
  "log",
@@ -6333,54 +6678,112 @@ dependencies = [
  "pdqselect",
  "rand 0.7.3",
  "retain_mut",
- "sc-client-api",
- "sc-consensus-epochs",
- "sc-consensus-slots",
- "sc-consensus-uncles",
- "sc-keystore",
- "sc-telemetry",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-consensus-epochs 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-consensus-slots 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-consensus-uncles 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-keystore 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-telemetry 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "schnorrkel",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-block-builder",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-babe",
- "sp-consensus-vrf",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
- "sp-timestamp",
- "sp-utils",
- "sp-version",
- "substrate-prometheus-endpoint",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-block-builder 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus-vrf 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-timestamp 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "sc-consensus-babe"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "derive_more",
+ "fork-tree 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "futures 0.3.8",
+ "futures-timer 3.0.2",
+ "log",
+ "merlin",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "parity-scale-codec 1.3.6",
+ "parking_lot 0.10.2",
+ "pdqselect",
+ "rand 0.7.3",
+ "retain_mut",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-consensus-epochs 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-consensus-slots 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-consensus-uncles 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-keystore 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-telemetry 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "schnorrkel",
+ "serde",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-block-builder 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-consensus-vrf 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-timestamp 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.8.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "derive_more",
  "futures 0.3.8",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
- "sc-consensus-babe",
- "sc-consensus-epochs",
- "sc-rpc-api",
+ "sc-consensus-babe 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-consensus-epochs 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-rpc-api 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-babe",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus-babe 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "sc-consensus-epochs"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "fork-tree 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "parity-scale-codec 1.3.6",
+ "parking_lot 0.10.2",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -6388,12 +6791,35 @@ name = "sc-consensus-epochs"
 version = "0.8.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "fork-tree",
+ "fork-tree 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "parity-scale-codec 1.3.6",
  "parking_lot 0.10.2",
- "sc-client-api",
- "sp-blockchain",
- "sp-runtime",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sc-consensus-slots"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "futures 0.3.8",
+ "futures-timer 3.0.2",
+ "log",
+ "parity-scale-codec 1.3.6",
+ "parking_lot 0.10.2",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-telemetry 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus-slots 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -6406,17 +6832,31 @@ dependencies = [
  "log",
  "parity-scale-codec 1.3.6",
  "parking_lot 0.10.2",
- "sc-client-api",
- "sc-telemetry",
- "sp-api",
- "sp-application-crypto",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-telemetry 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-consensus-slots 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sc-consensus-uncles"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "log",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-authorship 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -6425,12 +6865,41 @@ version = "0.8.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "log",
- "sc-client-api",
- "sp-authorship",
- "sp-consensus",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-authorship 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sc-executor"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "derive_more",
+ "lazy_static",
+ "libsecp256k1",
+ "log",
+ "parity-scale-codec 1.3.6",
+ "parity-wasm",
+ "parking_lot 0.10.2",
+ "sc-executor-common 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-executor-wasmi 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-executor-wasmtime",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-serializer 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-tasks 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-trie 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "wasmi",
 ]
 
 [[package]]
@@ -6445,20 +6914,36 @@ dependencies = [
  "parity-scale-codec 1.3.6",
  "parity-wasm",
  "parking_lot 0.10.2",
- "sc-executor-common",
- "sc-executor-wasmi",
- "sc-executor-wasmtime",
- "sp-api",
- "sp-core",
- "sp-externalities",
- "sp-io",
- "sp-panic-handler",
- "sp-runtime-interface",
- "sp-serializer",
- "sp-tasks",
- "sp-trie",
- "sp-version",
- "sp-wasm-interface",
+ "sc-executor-common 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-executor-wasmi 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-serializer 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-tasks 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-trie 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "wasmi",
+]
+
+[[package]]
+name = "sc-executor-common"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "derive_more",
+ "log",
+ "parity-scale-codec 1.3.6",
+ "parity-wasm",
+ "sp-allocator 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-serializer 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "wasmi",
 ]
 
@@ -6471,11 +6956,26 @@ dependencies = [
  "log",
  "parity-scale-codec 1.3.6",
  "parity-wasm",
- "sp-allocator",
- "sp-core",
- "sp-runtime-interface",
- "sp-serializer",
- "sp-wasm-interface",
+ "sp-allocator 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-serializer 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "wasmi",
+]
+
+[[package]]
+name = "sc-executor-wasmi"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "log",
+ "parity-scale-codec 1.3.6",
+ "sc-executor-common 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-allocator 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "wasmi",
 ]
 
@@ -6486,30 +6986,67 @@ source = "git+https://github.com/darwinia-network/substrate.git?branch=common-li
 dependencies = [
  "log",
  "parity-scale-codec 1.3.6",
- "sc-executor-common",
- "sp-allocator",
- "sp-core",
- "sp-runtime-interface",
- "sp-wasm-interface",
+ "sc-executor-common 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-allocator 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "wasmi",
 ]
 
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "log",
  "parity-scale-codec 1.3.6",
  "parity-wasm",
  "pwasm-utils",
- "sc-executor-common",
+ "sc-executor-common 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "scoped-tls",
- "sp-allocator",
- "sp-core",
- "sp-runtime-interface",
- "sp-wasm-interface",
+ "sp-allocator 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "wasmtime",
+]
+
+[[package]]
+name = "sc-finality-grandpa"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "derive_more",
+ "finality-grandpa",
+ "fork-tree 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "futures 0.3.8",
+ "futures-timer 3.0.2",
+ "log",
+ "parity-scale-codec 1.3.6",
+ "parking_lot 0.10.2",
+ "pin-project 0.4.27",
+ "rand 0.7.3",
+ "sc-block-builder 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-keystore 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-network 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-network-gossip 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-telemetry 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "serde_json",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-finality-grandpa 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -6519,7 +7056,7 @@ source = "git+https://github.com/darwinia-network/substrate.git?branch=common-li
 dependencies = [
  "derive_more",
  "finality-grandpa",
- "fork-tree",
+ "fork-tree 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "futures 0.3.8",
  "futures-timer 3.0.2",
  "log",
@@ -6527,32 +7064,32 @@ dependencies = [
  "parking_lot 0.10.2",
  "pin-project 0.4.27",
  "rand 0.7.3",
- "sc-block-builder",
- "sc-client-api",
- "sc-consensus",
- "sc-keystore",
- "sc-network",
- "sc-network-gossip",
- "sc-telemetry",
+ "sc-block-builder 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-keystore 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-network 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-network-gossip 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-telemetry 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "serde_json",
- "sp-api",
- "sp-application-crypto",
- "sp-arithmetic",
- "sp-blockchain",
- "sp-consensus",
- "sp-core",
- "sp-finality-grandpa",
- "sp-inherents",
- "sp-keystore",
- "sp-runtime",
- "sp-utils",
- "substrate-prometheus-endpoint",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-finality-grandpa 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -6563,14 +7100,32 @@ dependencies = [
  "jsonrpc-pubsub",
  "log",
  "parity-scale-codec 1.3.6",
- "sc-client-api",
- "sc-finality-grandpa",
- "sc-rpc",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-finality-grandpa 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-rpc 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "serde",
  "serde_json",
- "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "sc-informant"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "ansi_term 0.12.1",
+ "futures 0.3.8",
+ "log",
+ "parity-util-mem",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-network 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -6582,13 +7137,33 @@ dependencies = [
  "futures 0.3.8",
  "log",
  "parity-util-mem",
- "sc-client-api",
- "sc-network",
- "sp-blockchain",
- "sp-runtime",
- "sp-transaction-pool",
- "sp-utils",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-network 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "wasm-timer",
+]
+
+[[package]]
+name = "sc-keystore"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "async-trait",
+ "derive_more",
+ "futures 0.3.8",
+ "futures-util",
+ "hex",
+ "merlin",
+ "parking_lot 0.10.2",
+ "rand 0.7.3",
+ "serde_json",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "subtle 2.4.0",
 ]
 
 [[package]]
@@ -6605,10 +7180,29 @@ dependencies = [
  "parking_lot 0.10.2",
  "rand 0.7.3",
  "serde_json",
- "sp-application-crypto",
- "sp-core",
- "sp-keystore",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "subtle 2.4.0",
+]
+
+[[package]]
+name = "sc-light"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "hash-db",
+ "lazy_static",
+ "parity-scale-codec 1.3.6",
+ "parking_lot 0.10.2",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-executor 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -6620,20 +7214,20 @@ dependencies = [
  "lazy_static",
  "parity-scale-codec 1.3.6",
  "parking_lot 0.10.2",
- "sc-client-api",
- "sc-executor",
- "sp-api",
- "sp-blockchain",
- "sp-core",
- "sp-externalities",
- "sp-runtime",
- "sp-state-machine",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-executor 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "sc-network"
 version = "0.8.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "async-std",
  "async-trait",
@@ -6644,7 +7238,7 @@ dependencies = [
  "either",
  "erased-serde",
  "fnv",
- "fork-tree",
+ "fork-tree 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "futures 0.3.8",
  "futures-timer 3.0.2",
  "futures_codec",
@@ -6662,26 +7256,95 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sc-block-builder",
- "sc-client-api",
- "sc-peerset",
+ "sc-block-builder 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-peerset 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "serde",
  "serde_json",
  "slog",
  "slog_derive",
  "smallvec 0.6.14",
- "sp-arithmetic",
- "sp-blockchain",
- "sp-consensus",
- "sp-core",
- "sp-runtime",
- "sp-utils",
- "substrate-prometheus-endpoint",
+ "sp-arithmetic 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "thiserror",
  "unsigned-varint 0.4.0",
  "void",
  "wasm-timer",
  "zeroize",
+]
+
+[[package]]
+name = "sc-network"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "bitflags",
+ "bs58 0.3.1",
+ "bytes 0.5.6",
+ "derive_more",
+ "either",
+ "erased-serde",
+ "fnv",
+ "fork-tree 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "futures 0.3.8",
+ "futures-timer 3.0.2",
+ "futures_codec",
+ "hex",
+ "ip_network",
+ "libp2p",
+ "linked-hash-map",
+ "linked_hash_set",
+ "log",
+ "lru 0.4.3",
+ "nohash-hasher",
+ "parity-scale-codec 1.3.6",
+ "parking_lot 0.10.2",
+ "pin-project 0.4.27",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "sc-block-builder 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-peerset 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "serde",
+ "serde_json",
+ "slog",
+ "slog_derive",
+ "smallvec 0.6.14",
+ "sp-arithmetic 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "thiserror",
+ "unsigned-varint 0.4.0",
+ "void",
+ "wasm-timer",
+ "zeroize",
+]
+
+[[package]]
+name = "sc-network-gossip"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "futures 0.3.8",
+ "futures-timer 3.0.2",
+ "libp2p",
+ "log",
+ "lru 0.4.3",
+ "sc-network 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -6694,9 +7357,36 @@ dependencies = [
  "libp2p",
  "log",
  "lru 0.4.3",
- "sc-network",
- "sp-runtime",
+ "sc-network 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "wasm-timer",
+]
+
+[[package]]
+name = "sc-offchain"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "bytes 0.5.6",
+ "fnv",
+ "futures 0.3.8",
+ "futures-timer 3.0.2",
+ "hyper 0.13.10",
+ "hyper-rustls",
+ "log",
+ "num_cpus",
+ "parity-scale-codec 1.3.6",
+ "parking_lot 0.10.2",
+ "rand 0.7.3",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-keystore 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-network 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-offchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "threadpool",
 ]
 
 [[package]]
@@ -6715,15 +7405,28 @@ dependencies = [
  "parity-scale-codec 1.3.6",
  "parking_lot 0.10.2",
  "rand 0.7.3",
- "sc-client-api",
- "sc-keystore",
- "sc-network",
- "sp-api",
- "sp-core",
- "sp-offchain",
- "sp-runtime",
- "sp-utils",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-keystore 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-network 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-offchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "threadpool",
+]
+
+[[package]]
+name = "sc-peerset"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "futures 0.3.8",
+ "libp2p",
+ "log",
+ "serde_json",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -6735,17 +7438,50 @@ dependencies = [
  "libp2p",
  "log",
  "serde_json",
- "sp-utils",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "log",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "sc-rpc"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "futures 0.3.8",
+ "hash-db",
+ "jsonrpc-core",
+ "jsonrpc-pubsub",
+ "log",
+ "parity-scale-codec 1.3.6",
+ "parking_lot 0.10.2",
+ "sc-block-builder 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-executor 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-keystore 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-rpc-api 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "serde_json",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-chain-spec 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-offchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-rpc 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-session 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -6760,25 +7496,49 @@ dependencies = [
  "log",
  "parity-scale-codec 1.3.6",
  "parking_lot 0.10.2",
- "sc-block-builder",
- "sc-client-api",
- "sc-executor",
- "sc-keystore",
- "sc-rpc-api",
+ "sc-block-builder 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-executor 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-keystore 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-rpc-api 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "serde_json",
- "sp-api",
- "sp-blockchain",
- "sp-chain-spec",
- "sp-core",
- "sp-keystore",
- "sp-offchain",
- "sp-rpc",
- "sp-runtime",
- "sp-session",
- "sp-state-machine",
- "sp-transaction-pool",
- "sp-utils",
- "sp-version",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-chain-spec 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-offchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-rpc 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-session 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sc-rpc-api"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "derive_more",
+ "futures 0.3.8",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "jsonrpc-pubsub",
+ "log",
+ "parity-scale-codec 1.3.6",
+ "parking_lot 0.10.2",
+ "serde",
+ "serde_json",
+ "sp-chain-spec 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-rpc 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -6797,12 +7557,30 @@ dependencies = [
  "parking_lot 0.10.2",
  "serde",
  "serde_json",
- "sp-chain-spec",
- "sp-core",
- "sp-rpc",
- "sp-runtime",
- "sp-transaction-pool",
- "sp-version",
+ "sp-chain-spec 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-rpc 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sc-rpc-server"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "futures 0.1.30",
+ "jsonrpc-core",
+ "jsonrpc-http-server",
+ "jsonrpc-ipc-server",
+ "jsonrpc-pubsub",
+ "jsonrpc-ws-server",
+ "log",
+ "serde",
+ "serde_json",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -6819,8 +7597,72 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "sp-runtime",
- "substrate-prometheus-endpoint",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sc-service"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "derive_more",
+ "directories",
+ "exit-future",
+ "futures 0.1.30",
+ "futures 0.3.8",
+ "futures-timer 3.0.2",
+ "hash-db",
+ "jsonrpc-core",
+ "jsonrpc-pubsub",
+ "lazy_static",
+ "log",
+ "parity-scale-codec 1.3.6",
+ "parity-util-mem",
+ "parking_lot 0.10.2",
+ "pin-project 0.4.27",
+ "rand 0.7.3",
+ "sc-block-builder 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-chain-spec 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-client-db 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-executor 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-informant 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-keystore 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-light 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-network 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-offchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-rpc 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-rpc-server 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-telemetry 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "serde",
+ "serde_json",
+ "slog",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-block-builder 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-session 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-trie 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "tempfile",
+ "tracing",
+ "tracing-futures",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -6844,47 +7686,61 @@ dependencies = [
  "parking_lot 0.10.2",
  "pin-project 0.4.27",
  "rand 0.7.3",
- "sc-block-builder",
- "sc-chain-spec",
- "sc-client-api",
- "sc-client-db",
- "sc-executor",
- "sc-informant",
- "sc-keystore",
- "sc-light",
- "sc-network",
- "sc-offchain",
- "sc-rpc",
- "sc-rpc-server",
- "sc-telemetry",
- "sc-tracing",
- "sc-transaction-pool",
+ "sc-block-builder 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-chain-spec 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-client-db 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-executor 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-informant 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-keystore 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-light 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-network 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-offchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-rpc 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-rpc-server 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-telemetry 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "serde",
  "serde_json",
  "slog",
- "sp-api",
- "sp-application-crypto",
- "sp-block-builder",
- "sp-blockchain",
- "sp-consensus",
- "sp-core",
- "sp-externalities",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
- "sp-session",
- "sp-state-machine",
- "sp-tracing",
- "sp-transaction-pool",
- "sp-trie",
- "sp-utils",
- "sp-version",
- "substrate-prometheus-endpoint",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-block-builder 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-session 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-trie 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "tempfile",
  "tracing",
  "tracing-futures",
  "wasm-timer",
+]
+
+[[package]]
+name = "sc-state-db"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "log",
+ "parity-scale-codec 1.3.6",
+ "parity-util-mem",
+ "parity-util-mem-derive",
+ "parking_lot 0.10.2",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -6897,27 +7753,48 @@ dependencies = [
  "parity-util-mem",
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
- "sc-client-api",
- "sp-core",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.8.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
- "sc-chain-spec",
- "sc-client-api",
- "sc-consensus-babe",
- "sc-consensus-epochs",
- "sc-finality-grandpa",
- "sc-rpc-api",
+ "sc-chain-spec 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-consensus-babe 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-consensus-epochs 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-finality-grandpa 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-rpc-api 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "serde_json",
- "sp-blockchain",
- "sp-runtime",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "sc-telemetry"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "futures 0.3.8",
+ "futures-timer 3.0.2",
+ "libp2p",
+ "log",
+ "parking_lot 0.10.2",
+ "pin-project 0.4.27",
+ "rand 0.7.3",
+ "serde",
+ "slog",
+ "slog-json",
+ "slog-scope",
+ "take_mut",
+ "void",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -6944,20 +7821,60 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "erased-serde",
+ "log",
+ "parking_lot 0.10.2",
+ "rustc-hash",
+ "sc-telemetry 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "serde",
+ "serde_json",
+ "slog",
+ "sp-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sc-tracing"
+version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "erased-serde",
  "log",
  "parking_lot 0.10.2",
  "rustc-hash",
- "sc-telemetry",
+ "sc-telemetry 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "serde",
  "serde_json",
  "slog",
- "sp-tracing",
+ "sp-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "sc-transaction-graph"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "derive_more",
+ "futures 0.3.8",
+ "linked-hash-map",
+ "log",
+ "parity-util-mem",
+ "parking_lot 0.10.2",
+ "retain_mut",
+ "serde",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -6973,11 +7890,37 @@ dependencies = [
  "parking_lot 0.10.2",
  "retain_mut",
  "serde",
- "sp-blockchain",
- "sp-core",
- "sp-runtime",
- "sp-transaction-pool",
- "sp-utils",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "wasm-timer",
+]
+
+[[package]]
+name = "sc-transaction-pool"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "derive_more",
+ "futures 0.3.8",
+ "futures-diagnose",
+ "intervalier",
+ "log",
+ "parity-scale-codec 1.3.6",
+ "parity-util-mem",
+ "parking_lot 0.10.2",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-transaction-graph 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "wasm-timer",
 ]
 
@@ -6994,16 +7937,16 @@ dependencies = [
  "parity-scale-codec 1.3.6",
  "parity-util-mem",
  "parking_lot 0.10.2",
- "sc-client-api",
- "sc-transaction-graph",
- "sp-api",
- "sp-blockchain",
- "sp-core",
- "sp-runtime",
- "sp-tracing",
- "sp-transaction-pool",
- "sp-utils",
- "substrate-prometheus-endpoint",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sc-transaction-graph 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "wasm-timer",
 ]
 
@@ -7401,13 +8344,40 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "derive_more",
+ "log",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "sp-allocator"
+version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "derive_more",
  "log",
- "sp-core",
- "sp-std 2.0.0",
- "sp-wasm-interface",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-api"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "hash-db",
+ "parity-scale-codec 1.3.6",
+ "sp-api-proc-macro 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -7417,12 +8387,24 @@ source = "git+https://github.com/darwinia-network/substrate.git?branch=common-li
 dependencies = [
  "hash-db",
  "parity-scale-codec 1.3.6",
- "sp-api-proc-macro",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
- "sp-std 2.0.0",
- "sp-version",
+ "sp-api-proc-macro 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-api-proc-macro"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "blake2-rfc",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -7440,13 +8422,38 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "parity-scale-codec 1.3.6",
+ "serde",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "sp-application-crypto"
+version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-core",
- "sp-io",
- "sp-std 2.0.0",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-arithmetic"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "integer-sqrt",
+ "num-traits",
+ "parity-scale-codec 1.3.6",
+ "serde",
+ "sp-debug-derive 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -7458,20 +8465,31 @@ dependencies = [
  "num-traits",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-debug-derive",
- "sp-std 2.0.0",
+ "sp-debug-derive 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "parity-scale-codec 1.3.6",
- "sp-api",
- "sp-application-crypto",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "sp-authorship"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "parity-scale-codec 1.3.6",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -7480,9 +8498,21 @@ version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "parity-scale-codec 1.3.6",
- "sp-inherents",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-block-builder"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "parity-scale-codec 1.3.6",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -7491,10 +8521,27 @@ version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "parity-scale-codec 1.3.6",
- "sp-api",
- "sp-inherents",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-blockchain"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "derive_more",
+ "log",
+ "lru 0.4.3",
+ "parity-scale-codec 1.3.6",
+ "parking_lot 0.10.2",
+ "sp-block-builder 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-database 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -7507,11 +8554,20 @@ dependencies = [
  "lru 0.4.3",
  "parity-scale-codec 1.3.6",
  "parking_lot 0.10.2",
- "sp-block-builder",
- "sp-consensus",
- "sp-database",
- "sp-runtime",
- "sp-state-machine",
+ "sp-block-builder 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-database 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-chain-spec"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -7521,6 +8577,32 @@ source = "git+https://github.com/darwinia-network/substrate.git?branch=common-li
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "sp-consensus"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "derive_more",
+ "futures 0.3.8",
+ "futures-timer 3.0.2",
+ "libp2p",
+ "log",
+ "parity-scale-codec 1.3.6",
+ "parking_lot 0.10.2",
+ "serde",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-trie 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -7536,17 +8618,37 @@ dependencies = [
  "parity-scale-codec 1.3.6",
  "parking_lot 0.10.2",
  "serde",
- "sp-api",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
- "sp-std 2.0.0",
- "sp-trie",
- "sp-utils",
- "sp-version",
- "substrate-prometheus-endpoint",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-trie 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-utils 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-version 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "substrate-prometheus-endpoint 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "wasm-timer",
+]
+
+[[package]]
+name = "sp-consensus-babe"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "merlin",
+ "parity-scale-codec 1.3.6",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus-slots 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-consensus-vrf 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-timestamp 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -7556,17 +8658,26 @@ source = "git+https://github.com/darwinia-network/substrate.git?branch=common-li
 dependencies = [
  "merlin",
  "parity-scale-codec 1.3.6",
- "sp-api",
- "sp-application-crypto",
- "sp-consensus",
- "sp-consensus-slots",
- "sp-consensus-vrf",
- "sp-core",
- "sp-inherents",
- "sp-keystore",
- "sp-runtime",
- "sp-std 2.0.0",
- "sp-timestamp",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-consensus 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-consensus-slots 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-consensus-vrf 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-timestamp 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-consensus-slots"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "parity-scale-codec 1.3.6",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -7575,7 +8686,19 @@ version = "0.8.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "parity-scale-codec 1.3.6",
- "sp-runtime",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-consensus-vrf"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "parity-scale-codec 1.3.6",
+ "schnorrkel",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -7585,9 +8708,52 @@ source = "git+https://github.com/darwinia-network/substrate.git?branch=common-li
 dependencies = [
  "parity-scale-codec 1.3.6",
  "schnorrkel",
- "sp-core",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-core"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "base58",
+ "blake2-rfc",
+ "byteorder 1.4.2",
+ "dyn-clonable",
+ "ed25519-dalek",
+ "futures 0.3.8",
+ "hash-db",
+ "hash256-std-hasher",
+ "hex",
+ "impl-serde 0.3.1",
+ "lazy_static",
+ "libsecp256k1",
+ "log",
+ "merlin",
+ "num-traits",
+ "parity-scale-codec 1.3.6",
+ "parity-util-mem",
+ "parking_lot 0.10.2",
+ "primitive-types 0.7.3",
+ "rand 0.7.3",
+ "regex",
+ "schnorrkel",
+ "secrecy",
+ "serde",
+ "sha2 0.8.2",
+ "sp-debug-derive 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-storage 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "substrate-bip39",
+ "tiny-bip39",
+ "tiny-keccak 2.0.2",
+ "twox-hash",
+ "wasmi",
+ "zeroize",
 ]
 
 [[package]]
@@ -7620,11 +8786,11 @@ dependencies = [
  "secrecy",
  "serde",
  "sha2 0.8.2",
- "sp-debug-derive",
- "sp-externalities",
- "sp-runtime-interface",
- "sp-std 2.0.0",
- "sp-storage",
+ "sp-debug-derive 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-storage 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "substrate-bip39",
  "tiny-bip39",
  "tiny-keccak 2.0.2",
@@ -7636,10 +8802,29 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "kvdb",
+ "parking_lot 0.10.2",
+]
+
+[[package]]
+name = "sp-database"
+version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
+]
+
+[[package]]
+name = "sp-debug-derive"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -7655,12 +8840,40 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "environmental",
+ "parity-scale-codec 1.3.6",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-storage 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "sp-externalities"
+version = "0.8.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "environmental",
  "parity-scale-codec 1.3.6",
- "sp-std 2.0.0",
- "sp-storage",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-storage 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-finality-grandpa"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "finality-grandpa",
+ "log",
+ "parity-scale-codec 1.3.6",
+ "serde",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -7672,12 +8885,24 @@ dependencies = [
  "log",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-inherents"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "derive_more",
+ "parity-scale-codec 1.3.6",
+ "parking_lot 0.10.2",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -7688,8 +8913,32 @@ dependencies = [
  "derive_more",
  "parity-scale-codec 1.3.6",
  "parking_lot 0.10.2",
- "sp-core",
- "sp-std 2.0.0",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-io"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "futures 0.3.8",
+ "hash-db",
+ "libsecp256k1",
+ "log",
+ "parity-scale-codec 1.3.6",
+ "parking_lot 0.10.2",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-trie 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]
@@ -7703,17 +8952,28 @@ dependencies = [
  "log",
  "parity-scale-codec 1.3.6",
  "parking_lot 0.10.2",
- "sp-core",
- "sp-externalities",
- "sp-keystore",
- "sp-runtime-interface",
- "sp-state-machine",
- "sp-std 2.0.0",
- "sp-tracing",
- "sp-trie",
- "sp-wasm-interface",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-keystore 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-state-machine 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-trie 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "tracing",
  "tracing-core",
+]
+
+[[package]]
+name = "sp-keyring"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "lazy_static",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "strum",
 ]
 
 [[package]]
@@ -7722,9 +8982,25 @@ version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "lazy_static",
- "sp-core",
- "sp-runtime",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "strum",
+]
+
+[[package]]
+name = "sp-keystore"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "async-trait",
+ "derive_more",
+ "futures 0.3.8",
+ "merlin",
+ "parity-scale-codec 1.3.6",
+ "parking_lot 0.10.2",
+ "schnorrkel",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -7739,8 +9015,8 @@ dependencies = [
  "parity-scale-codec 1.3.6",
  "parking_lot 0.10.2",
  "schnorrkel",
- "sp-core",
- "sp-externalities",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
@@ -7750,9 +9026,9 @@ source = "git+https://github.com/darwinia-network/substrate.git?branch=common-li
 dependencies = [
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-arithmetic",
+ "sp-arithmetic 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "sp-npos-elections-compact",
- "sp-std 2.0.0",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
 ]
 
 [[package]]
@@ -7769,11 +9045,30 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "sp-offchain"
+version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
- "sp-api",
- "sp-core",
- "sp-runtime",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-panic-handler"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "backtrace",
+ "log",
 ]
 
 [[package]]
@@ -7788,10 +9083,41 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "serde",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "sp-rpc"
+version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "serde",
- "sp-core",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-runtime"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "either",
+ "hash256-std-hasher",
+ "impl-trait-for-tuples 0.1.3",
+ "log",
+ "parity-scale-codec 1.3.6",
+ "parity-util-mem",
+ "paste",
+ "rand 0.7.3",
+ "serde",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -7808,12 +9134,28 @@ dependencies = [
  "paste",
  "rand 0.7.3",
  "serde",
- "sp-application-crypto",
- "sp-arithmetic",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-std 2.0.0",
+ "sp-application-crypto 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-arithmetic 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-runtime-interface"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "parity-scale-codec 1.3.6",
+ "primitive-types 0.7.3",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-storage 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "static_assertions",
 ]
 
 [[package]]
@@ -7823,13 +9165,25 @@ source = "git+https://github.com/darwinia-network/substrate.git?branch=common-li
 dependencies = [
  "parity-scale-codec 1.3.6",
  "primitive-types 0.7.3",
- "sp-externalities",
- "sp-runtime-interface-proc-macro",
- "sp-std 2.0.0",
- "sp-storage",
- "sp-tracing",
- "sp-wasm-interface",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime-interface-proc-macro 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-storage 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-tracing 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-wasm-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "static_assertions",
+]
+
+[[package]]
+name = "sp-runtime-interface-proc-macro"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "Inflector",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -7847,6 +9201,15 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sp-serializer"
+version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "serde",
@@ -7856,14 +9219,37 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "parity-scale-codec 1.3.6",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-staking 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "sp-session"
+version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "parity-scale-codec 1.3.6",
- "sp-api",
- "sp-core",
- "sp-runtime",
- "sp-staking",
- "sp-std 2.0.0",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-staking 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-staking"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "parity-scale-codec 1.3.6",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -7872,8 +9258,29 @@ version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "parity-scale-codec 1.3.6",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-state-machine"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "hash-db",
+ "log",
+ "num-traits",
+ "parity-scale-codec 1.3.6",
+ "parking_lot 0.10.2",
+ "rand 0.7.3",
+ "smallvec 1.6.1",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-trie 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "trie-db",
+ "trie-root",
 ]
 
 [[package]]
@@ -7888,11 +9295,11 @@ dependencies = [
  "parking_lot 0.10.2",
  "rand 0.7.3",
  "smallvec 1.6.1",
- "sp-core",
- "sp-externalities",
- "sp-panic-handler",
- "sp-std 2.0.0",
- "sp-trie",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-panic-handler 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-trie 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "trie-db",
  "trie-root",
 ]
@@ -7905,7 +9312,25 @@ source = "git+https://github.com/darwinia-network/substrate.git?branch=darwinia-
 [[package]]
 name = "sp-std"
 version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+
+[[package]]
+name = "sp-std"
+version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+
+[[package]]
+name = "sp-storage"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "impl-serde 0.3.1",
+ "parity-scale-codec 1.3.6",
+ "ref-cast",
+ "serde",
+ "sp-debug-derive 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
 
 [[package]]
 name = "sp-storage"
@@ -7916,8 +9341,21 @@ dependencies = [
  "parity-scale-codec 1.3.6",
  "ref-cast",
  "serde",
- "sp-debug-derive",
- "sp-std 2.0.0",
+ "sp-debug-derive 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-tasks"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "log",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -7926,11 +9364,25 @@ version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "log",
- "sp-core",
- "sp-externalities",
- "sp-io",
- "sp-runtime-interface",
- "sp-std 2.0.0",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-externalities 0.8.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-io 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime-interface 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-timestamp"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "impl-trait-for-tuples 0.1.3",
+ "parity-scale-codec 1.3.6",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -7940,11 +9392,24 @@ source = "git+https://github.com/darwinia-network/substrate.git?branch=common-li
 dependencies = [
  "impl-trait-for-tuples 0.1.3",
  "parity-scale-codec 1.3.6",
- "sp-api",
- "sp-inherents",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-inherents 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "wasm-timer",
+]
+
+[[package]]
+name = "sp-tracing"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "log",
+ "parity-scale-codec 1.3.6",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -7954,10 +9419,25 @@ source = "git+https://github.com/darwinia-network/substrate.git?branch=common-li
 dependencies = [
  "log",
  "parity-scale-codec 1.3.6",
- "sp-std 2.0.0",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "sp-transaction-pool"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "derive_more",
+ "futures 0.3.8",
+ "log",
+ "parity-scale-codec 1.3.6",
+ "serde",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
 ]
 
 [[package]]
@@ -7970,9 +9450,23 @@ dependencies = [
  "log",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-api",
- "sp-blockchain",
- "sp-runtime",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-trie"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "hash-db",
+ "memory-db",
+ "parity-scale-codec 1.3.6",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "trie-db",
+ "trie-root",
 ]
 
 [[package]]
@@ -7983,10 +9477,22 @@ dependencies = [
  "hash-db",
  "memory-db",
  "parity-scale-codec 1.3.6",
- "sp-core",
- "sp-std 2.0.0",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "trie-db",
  "trie-root",
+]
+
+[[package]]
+name = "sp-utils"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "futures 0.3.8",
+ "futures-core",
+ "futures-timer 3.0.2",
+ "lazy_static",
+ "prometheus",
 ]
 
 [[package]]
@@ -8004,13 +9510,36 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "impl-serde 0.3.1",
+ "parity-scale-codec 1.3.6",
+ "serde",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "sp-version"
+version = "2.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "impl-serde 0.3.1",
  "parity-scale-codec 1.3.6",
  "serde",
- "sp-runtime",
- "sp-std 2.0.0",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
+]
+
+[[package]]
+name = "sp-wasm-interface"
+version = "2.0.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "impl-trait-for-tuples 0.1.3",
+ "parity-scale-codec 1.3.6",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "wasmi",
 ]
 
 [[package]]
@@ -8020,7 +9549,7 @@ source = "git+https://github.com/darwinia-network/substrate.git?branch=common-li
 dependencies = [
  "impl-trait-for-tuples 0.1.3",
  "parity-scale-codec 1.3.6",
- "sp-std 2.0.0",
+ "sp-std 2.0.0 (git+https://github.com/darwinia-network/substrate.git?branch=common-library)",
  "wasmi",
 ]
 
@@ -8137,7 +9666,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -8151,11 +9680,11 @@ dependencies = [
  "log",
  "rand 0.6.5",
  "rand 0.7.3",
- "sc-chain-spec",
- "sc-informant",
- "sc-network",
- "sc-service",
- "sp-database",
+ "sc-chain-spec 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-informant 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-network 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-service 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-database 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -8163,7 +9692,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "platforms",
 ]
@@ -8180,7 +9709,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.8",
@@ -8189,15 +9718,29 @@ dependencies = [
  "jsonrpc-derive",
  "log",
  "parity-scale-codec 1.3.6",
- "sc-client-api",
- "sc-rpc-api",
+ "sc-client-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sc-rpc-api 0.8.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
  "serde",
- "sp-api",
- "sp-block-builder",
- "sp-blockchain",
- "sp-core",
- "sp-runtime",
- "sp-transaction-pool",
+ "sp-api 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-block-builder 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-blockchain 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-core 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-runtime 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+ "sp-transaction-pool 2.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia)",
+]
+
+[[package]]
+name = "substrate-prometheus-endpoint"
+version = "0.8.0"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
+dependencies = [
+ "async-std",
+ "derive_more",
+ "futures-util",
+ "hyper 0.13.10",
+ "log",
+ "prometheus",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -8217,7 +9760,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/substrate.git?branch=common-library#668ecade60abe5a644868aefd3d231c9839fe652"
+source = "git+https://github.com/darwinia-network/substrate.git?tag=v2.1.0-darwinia#668ecade60abe5a644868aefd3d231c9839fe652"
 
 [[package]]
 name = "subtle"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,26 +26,26 @@ tokio                = { version = "0.3.5", optional = true, features = ["rt-mul
 wasm-bindgen         = { version = "0.2.69", optional = true }
 wasm-bindgen-futures = { version = "0.4.19", optional = true }
 # darwinia client
-darwinia-cli = { optional = true, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
+darwinia-cli = { optional = true, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
 # darwinia service
 darwinia-service = { default-features = false, path = "../node/service" }
 # substrate client
-sc-cli        = { optional = true, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-client-api = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-executor   = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-network    = { optional = true, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-service    = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-tracing    = { optional = true, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+sc-cli        = { optional = true, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-client-api = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-executor   = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-network    = { optional = true, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-service    = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-tracing    = { optional = true, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 # substrate primitives
-sp-core = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+sp-core = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 # this crate is used only to enable `trie-memory-tracker` feature
 # see https://github.com/paritytech/substrate/pull/6745
-sp-trie = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+sp-trie = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 # substrate utils
-substrate-browser-utils = { optional = true, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+substrate-browser-utils = { optional = true, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 
 [build-dependencies]
-substrate-build-script-utils = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+substrate-build-script-utils = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 
 [features]
 default = [

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -17,9 +17,9 @@ log         = { version = "0.4.13" }
 serde       = { version = "1.0.118", features = ["derive"] }
 serde_json  = { version = "1.0.61" }
 # darwinia frame
-darwinia-balances-rpc-runtime-api   = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-header-mmr-rpc-runtime-api = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-staking-rpc-runtime-api    = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
+darwinia-balances-rpc-runtime-api   = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-header-mmr-rpc-runtime-api = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-staking-rpc-runtime-api    = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
 # darwinia primitives
 darwinia-primitives = { path = "../../primitives" }
 # darwinia rpc
@@ -28,39 +28,39 @@ darwinia-rpc = { path = "../../rpc" }
 crab-runtime     = { path = "../../runtime/crab" }
 darwinia-runtime = { path = "../../runtime/darwinia" }
 # substrate client
-sc-authority-discovery = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-basic-authorship    = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-chain-spec          = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-client-api          = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-client-db           = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-consensus           = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-consensus-babe      = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-executor            = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-finality-grandpa    = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-network             = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-service             = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-telemetry           = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-transaction-pool    = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+sc-authority-discovery = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-basic-authorship    = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-chain-spec          = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-client-api          = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-client-db           = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-consensus           = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-consensus-babe      = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-executor            = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-finality-grandpa    = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-network             = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-service             = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-telemetry           = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-transaction-pool    = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 # substrate frame
-frame-system-rpc-runtime-api               = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-im-online                           = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-substrate-prometheus-endpoint              = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+frame-system-rpc-runtime-api               = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-im-online                           = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+substrate-prometheus-endpoint              = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 # substrate primitives
-sp-api                 = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-authority-discovery = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-block-builder       = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-blockchain          = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-consensus           = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-consensus-babe      = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-core                = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-finality-grandpa    = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-inherents           = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-offchain            = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-runtime             = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-session             = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-transaction-pool    = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-trie                = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+sp-api                 = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-authority-discovery = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-block-builder       = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-blockchain          = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-consensus           = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-consensus-babe      = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-core                = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-finality-grandpa    = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-inherents           = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-offchain            = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-runtime             = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-session             = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-transaction-pool    = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-trie                = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 
 [features]
 default = ["db", "full-node"]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -12,11 +12,11 @@ version     = "0.9.5"
 # crates
 codec = { package = "parity-scale-codec", version = "1.3.5", default-features = false }
 # substrate frame
-frame-system = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+frame-system = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 # substrate primitives
-sp-application-crypto = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-core               = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-runtime            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+sp-application-crypto = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-core               = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-runtime            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 
 [features]
 default = ["std"]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -13,30 +13,30 @@ version     = "0.9.5"
 codec        = { package = "parity-scale-codec", version = "1.3.5", default-features = false }
 jsonrpc-core = { version = "15.1.0" }
 # darwinia frame
-darwinia-balances-rpc   = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-header-mmr-rpc = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-staking-rpc    = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
+darwinia-balances-rpc   = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-header-mmr-rpc = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-staking-rpc    = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
 # darwinia primitives
 darwinia-primitives = { path = "../primitives" }
 # substrate client
-sc-chain-spec           = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-client-api           = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-consensus-babe       = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-consensus-babe-rpc   = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-consensus-epochs     = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-finality-grandpa     = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-finality-grandpa-rpc = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-rpc                  = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sc-sync-state-rpc       = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+sc-chain-spec           = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-client-api           = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-consensus-babe       = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-consensus-babe-rpc   = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-consensus-epochs     = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-finality-grandpa     = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-finality-grandpa-rpc = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-rpc                  = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sc-sync-state-rpc       = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 # substrate frame
-pallet-transaction-payment-rpc = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-substrate-frame-rpc-system     = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+pallet-transaction-payment-rpc = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+substrate-frame-rpc-system     = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 # substrate primitives
-sp-api              = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-block-builder    = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-blockchain       = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-consensus        = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-consensus-babe   = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-keystore         = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-runtime          = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-transaction-pool = { git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+sp-api              = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-block-builder    = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-blockchain       = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-consensus        = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-consensus-babe   = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-keystore         = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-runtime          = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-transaction-pool = { git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -13,19 +13,19 @@ version     = "0.9.5"
 codec             = { package = "parity-scale-codec", version = "1.3.5", default-features = false }
 static_assertions = { version = "1.1.0" }
 # darwinia frame
-darwinia-balances = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-staking  = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-support  = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
+darwinia-balances = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-staking  = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-support  = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
 # darwinia primitives
 darwinia-primitives = { default-features = false, path = "../../primitives" }
 # substrate frame
-frame-support              = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-frame-system               = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-authorship          = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-transaction-payment = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+frame-support              = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+frame-system               = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-authorship          = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-transaction-payment = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 # substrate primitives
-sp-runtime = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-std     = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+sp-runtime = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-std     = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 
 [features]
 default = ["std"]

--- a/runtime/crab/Cargo.toml
+++ b/runtime/crab/Cargo.toml
@@ -17,72 +17,72 @@ serde             = { version = "1.0.118", optional = true }
 smallvec          = { version = "1.6.1" }
 static_assertions = { version = "1.1.0" }
 # darwinia frame
-darwinia-balances                   = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-balances-rpc-runtime-api   = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-claims                     = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-crab-issuing               = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-democracy                  = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-elections-phragmen         = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-ethereum-backing           = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-ethereum-relay             = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-header-mmr                 = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-header-mmr-rpc-runtime-api = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-relay-authorities          = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-relay-primitives           = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-relayer-game               = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-staking                    = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-staking-rpc-runtime-api    = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-support                    = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-treasury                   = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
+darwinia-balances                   = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-balances-rpc-runtime-api   = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-claims                     = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-crab-issuing               = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-democracy                  = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-elections-phragmen         = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-ethereum-backing           = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-ethereum-relay             = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-header-mmr                 = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-header-mmr-rpc-runtime-api = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-relay-authorities          = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-relay-primitives           = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-relayer-game               = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-staking                    = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-staking-rpc-runtime-api    = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-support                    = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-treasury                   = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
 # darwinia primitives
 darwinia-primitives = { default-features = false, path = "../../primitives" }
-ethereum-primitives = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
+ethereum-primitives = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
 # darwinia runtime
 darwinia-runtime-common = { default-features = false, path = "../common" }
 # substrate frame
-frame-executive                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-frame-support                              = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-frame-system                               = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-frame-system-rpc-runtime-api               = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-authority-discovery                 = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-authorship                          = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-babe                                = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-collective                          = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-grandpa                             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-identity                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-im-online                           = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-indices                             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-membership                          = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-multisig                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-offences                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-proxy                               = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-randomness-collective-flip          = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-recovery                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-scheduler                           = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-session                             = { default-features = false, features = ["historical"], git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-society                             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-sudo                                = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-timestamp                           = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-transaction-payment                 = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-utility                             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+frame-executive                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+frame-support                              = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+frame-system                               = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+frame-system-rpc-runtime-api               = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-authority-discovery                 = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-authorship                          = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-babe                                = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-collective                          = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-grandpa                             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-identity                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-im-online                           = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-indices                             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-membership                          = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-multisig                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-offences                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-proxy                               = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-randomness-collective-flip          = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-recovery                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-scheduler                           = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-session                             = { default-features = false, features = ["historical"], git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-society                             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-sudo                                = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-timestamp                           = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-transaction-payment                 = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-utility                             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 # substrate primitives
-sp-api                 = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-authority-discovery = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-block-builder       = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-consensus-babe      = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-core                = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-inherents           = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-offchain            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-runtime             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-session             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-staking             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-std                 = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-transaction-pool    = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-version             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+sp-api                 = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-authority-discovery = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-block-builder       = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-consensus-babe      = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-core                = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-inherents           = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-offchain            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-runtime             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-session             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-staking             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-std                 = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-transaction-pool    = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-version             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 
 [features]
 default = ["std"]

--- a/runtime/darwinia/Cargo.toml
+++ b/runtime/darwinia/Cargo.toml
@@ -18,72 +18,72 @@ serde_json        = { version = "1.0.61", optional = true }
 smallvec          = { version = "1.6.1" }
 static_assertions = { version = "1.1.0" }
 # darwinia frame
-darwinia-balances                   = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-balances-rpc-runtime-api   = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-crab-backing               = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-democracy                  = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-elections-phragmen         = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-ethereum-backing           = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-ethereum-relay             = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-header-mmr                 = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-header-mmr-rpc-runtime-api = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-relay-authorities          = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-relay-primitives           = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-relayer-game               = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-staking                    = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-staking-rpc-runtime-api    = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-support                    = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-treasury                   = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-tron-backing               = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
-darwinia-vesting                    = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
+darwinia-balances                   = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-balances-rpc-runtime-api   = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-crab-backing               = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-democracy                  = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-elections-phragmen         = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-ethereum-backing           = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-ethereum-relay             = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-header-mmr                 = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-header-mmr-rpc-runtime-api = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-relay-authorities          = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-relay-primitives           = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-relayer-game               = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-staking                    = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-staking-rpc-runtime-api    = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-support                    = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-treasury                   = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-tron-backing               = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
+darwinia-vesting                    = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
 # darwinia primitives
 darwinia-primitives = { default-features = false, path = "../../primitives" }
-ethereum-primitives = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", branch = "master" }
+ethereum-primitives = { default-features = false, git = "https://github.com/darwinia-network/darwinia-common.git", tag = "1.3.3" }
 # darwinia runtime
 darwinia-runtime-common = { default-features = false, path = "../common" }
 # substrate frame
-frame-executive                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-frame-support                              = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-frame-system                               = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-frame-system-rpc-runtime-api               = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-authority-discovery                 = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-authorship                          = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-babe                                = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-collective                          = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-grandpa                             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-identity                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-im-online                           = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-membership                          = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-multisig                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-offences                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-proxy                               = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-randomness-collective-flip          = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-recovery                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-scheduler                           = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-session                             = { default-features = false, features = ["historical"], git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-society                             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-sudo                                = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-timestamp                           = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-transaction-payment                 = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-pallet-utility                             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+frame-executive                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+frame-support                              = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+frame-system                               = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+frame-system-rpc-runtime-api               = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-authority-discovery                 = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-authorship                          = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-babe                                = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-collective                          = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-grandpa                             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-identity                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-im-online                           = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-membership                          = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-multisig                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-offences                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-proxy                               = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-randomness-collective-flip          = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-recovery                            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-scheduler                           = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-session                             = { default-features = false, features = ["historical"], git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-society                             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-sudo                                = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-timestamp                           = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-transaction-payment                 = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+pallet-utility                             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 # substrate primitives
-sp-api                 = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-authority-discovery = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-block-builder       = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-consensus-babe      = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-core                = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-inherents           = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-offchain            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-runtime             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-session             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-staking             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-std                 = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-transaction-pool    = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
-sp-version             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+sp-api                 = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-authority-discovery = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-block-builder       = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-consensus-babe      = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-core                = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-inherents           = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-offchain            = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-runtime             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-session             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-staking             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-std                 = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-transaction-pool    = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
+sp-version             = { default-features = false, git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/darwinia-network/substrate.git", branch = "common-library" }
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/darwinia-network/substrate.git", tag = "v2.1.0-darwinia" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Currently, there're too many versions. (pangolin, dvm, master, rococo)

Switch the deps source from master to a specific tag.