### PR TITLE
update commit hash short digit length 8 to 7

### DIFF
--- a/.maintain/setup-image.sh
+++ b/.maintain/setup-image.sh
@@ -10,7 +10,7 @@ WORK_PATH=${BIN_PATH}/../
 
 
 TAG_NAME=$(echo $GITHUB_REF | cut -d'/' -f 3)
-GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c1-8)
+GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c1-7)
 
 IMAGE_ORIGIN_NAME=darwinia:${TAG_NAME}
 


### PR DESCRIPTION

the version v0.9.6 release build have some question. `sha-` docker image tag name is wrong, should use length 7 digit hash not 8.
need merge before the next release publish