### PR TITLE
Tag v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,67 @@
+## [0.11.0-fix-storage] - 2021-07-29
+
+### Upgrade Priority: LOG
+#### Upgrade Window Period - 升级窗口期
+- None
+
+#### Breaking Change(s)
+- None
+
+### Darwinia 0.11.0-fix-storage
+
+|  Chain   | Runtime Spec Version |
+| :------: | :------------------: |
+| Darwinia |         1101         |
+|   Crab   |         1100         |
+
+### Boot Flag
+
+#### Darwinia
+**Run with `--chain darwinia` or leave it empty to participate in Darwinia.**
+**使用 `--chain darwinia` 或不填写，参与到 Darwinia 网络。**
+
+#### Crab
+**Run with `--chain crab` to participate in Crab.**
+**使用 `--chain crab` ，参与到 Crab 网络。**
+
+### Resource
+
+#### Binary
+|               |  Arch  | glibc (at least) | llvm (at least) | pre-built |
+| :-----------: | :----: | :--------------: | :-------------: | :-------: |
+| General Linux | x86_64 |       2.23       |       4.0       |     ✔︎     |
+
+#### Docker
+```docker
+docker pull quay.io/darwinia-network/darwinia:v0.11.0-fix-storage
+```
+
+### Change Log
+
+#### Update(s)
+- None
+#### Fix(es)
+- None
+#### Migration(s)
+- None
+
+---
+
+#### Darwinia Custom
+##### Runtime
+- Although this version is released after 1110, but it will be upgraded first before 1110
+##### Migration(s)
+- Migrate `DarwiniaEthereumBacking` to `EthereumBacking`
+
+---
+
+#### Crab Custom
+##### Runtime
+- None
+##### Migration(s)
+- None
+
+
 ## [0.11.1] - 2021-07-28
 
 ### Upgrade Priority: MEDIUM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,71 @@
+## [0.11.2] - 2021-08-03
+
+### Upgrade Priority: LOW
+#### Upgrade Window Period - 升级窗口期
+- None
+
+#### Breaking Change(s)
+- None
+
+### Darwinia 0.11.2
+
+|  Chain   | Runtime Spec Version |
+| :------: | :------------------: |
+| Darwinia |         1120         |
+|   Crab   |         1120         |
+
+### Boot Flag
+
+#### Darwinia
+**Run with `--chain darwinia` or leave it empty to participate in Darwinia.**
+**使用 `--chain darwinia` 或不填写，参与到 Darwinia 网络。**
+
+#### Crab
+**Run with `--chain crab` to participate in Crab.**
+**使用 `--chain crab` ，参与到 Crab 网络。**
+
+### Resource
+
+#### Binary
+|               |  Arch  | glibc (at least) | llvm (at least) | pre-built |
+| :-----------: | :----: | :--------------: | :-------------: | :-------: |
+| General Linux | x86_64 |       2.23       |       4.0       |     ✔︎     |
+
+#### Docker
+```docker
+docker pull quay.io/darwinia-network/darwinia:v0.11.2
+```
+
+#### Update(s)
+- Updates [C 604](https://github.com/darwinia-network/darwinia-common/pull/604), [C 644](https://github.com/darwinia-network/darwinia-common/pull/644), [C 648](https://github.com/darwinia-network/darwinia-common/pull/648), [C 652](https://github.com/darwinia-network/darwinia-common/pull/652), [C 654](https://github.com/darwinia-network/darwinia-common/pull/654), [C 686](https://gith,ub.com/darwinia-network/darwinia-common/pull/686), [C 703](https://github.com/darwinia-network/darwinia-common/pull/703), [C 708](https://github.com/darwinia-network/darwinia-common/pull/708), [C 718](https://github.com/darwinia-network/darwinia-common/pull/718), [C 729](https://github.com/darwinia-network/darwinia-common/pull/729)
+- Only For Darwinia Developers [R 22](https://github.com/darwinia-network/substrate-update-tracking/issues/22)
+#### Fix(es)
+- None
+#### Migration(s)
+- https://github.com/paritytech/substrate/pull/8773 we don't have this pallet
+- https://github.com/paritytech/substrate/pull/8769 it's okay we never modify the `Scheduler` in `construct_runtime!`
+- #696 Remove `darwinia-header-mmr`'s Patches
+
+---
+
+#### Darwinia Custom
+##### Update(s)
+- [Support London Updates](https://github.com/darwinia-network/darwinia-common/pull/708)
+##### Migration(s)
+- #696 Support London Updates
+
+---
+
+#### Crab Custom
+##### Update(s)
+- None
+##### Migration(s)
+- None
+
+
 ## [0.11.0-fix-storage] - 2021-07-29
 
-### Upgrade Priority: LOG
+### Upgrade Priority: LOW
 #### Upgrade Window Period - 升级窗口期
 - None
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,7 +942,7 @@ checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "crab-runtime"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "array-bytes",
  "darwinia-balances",
@@ -1300,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "darwinia"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
- "darwinia-cli 0.11.1",
+ "darwinia-cli 0.11.2",
  "darwinia-service",
  "futures 0.3.16",
  "parity-util-mem",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-cli"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "darwinia-cli 2.5.0",
  "darwinia-service",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-primitives"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-rpc"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "crab-runtime",
  "darwinia-balances-rpc",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-runtime"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "darwinia-balances",
  "darwinia-balances-rpc-runtime-api",
@@ -1784,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-runtime-common"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "darwinia-balances",
  "darwinia-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,9 +447,6 @@ name = "beef"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bed554bd50246729a1ec158d08aa3235d1b69d94ad120ebe187e28894787e736"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bincode"
@@ -3414,17 +3411,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-body"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
-dependencies = [
- "bytes 1.0.1",
- "http 0.2.4",
- "pin-project-lite 0.2.7",
-]
-
-[[package]]
 name = "httparse"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3435,12 +3421,6 @@ name = "httpdate"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
-
-[[package]]
-name = "httpdate"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "humantime"
@@ -3501,33 +3481,11 @@ dependencies = [
  "http 0.2.4",
  "http-body 0.3.1",
  "httparse",
- "httpdate 0.3.2",
+ "httpdate",
  "itoa",
  "pin-project 1.0.8",
  "socket2 0.3.19",
  "tokio 0.2.25",
- "tower-service",
- "tracing",
- "want 0.3.0",
-]
-
-[[package]]
-name = "hyper"
-version = "0.14.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
-dependencies = [
- "bytes 1.0.1",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 0.2.4",
- "http-body 0.4.2",
- "httparse",
- "httpdate 1.0.1",
- "itoa",
- "pin-project-lite 0.2.7",
- "tokio 1.9.0",
  "tower-service",
  "tracing",
  "want 0.3.0",
@@ -3939,27 +3897,25 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.2.0"
+version = "0.2.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cf7bd4e93b3b56e59131de7f24afbea871faf914e97bcdd942c86927ab0172"
+checksum = "bab3dabceeeeb865897661d532d47202eaae71cd2c606f53cb69f1fbc0555a51"
 dependencies = [
  "async-trait",
  "beef",
  "futures-channel",
  "futures-util",
- "hyper 0.14.11",
  "log",
  "serde",
  "serde_json",
- "soketto 0.5.0",
  "thiserror",
 ]
 
 [[package]]
 name = "jsonrpsee-utils"
-version = "0.2.0"
+version = "0.2.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47554ecaacb479285da68799d9b6afc258c32b332cc8b85829c6a9304ee98776"
+checksum = "d63cf4d423614e71fd144a8691208539d2b23d8373e069e2fbe023c5eba5e922"
 dependencies = [
  "futures-util",
  "hyper 0.13.10",
@@ -4506,7 +4462,7 @@ dependencies = [
  "log",
  "quicksink",
  "rw-stream-sink",
- "soketto 0.4.2",
+ "soketto",
  "url 2.2.2",
  "webpki-roots",
 ]
@@ -8045,21 +8001,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "soketto"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4919971d141dbadaa0e82b5d369e2d7666c98e4625046140615ca363e50d4daa"
-dependencies = [
- "base64 0.13.0",
- "bytes 1.0.1",
- "futures 0.3.16",
- "httparse",
- "log",
- "rand 0.8.4",
- "sha-1 0.9.7",
-]
-
-[[package]]
 name = "sp-allocator"
 version = "3.0.0"
 source = "git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.2#1d7f6e12c651d776fc0dc1adefd007bb60f60b63"
@@ -9169,16 +9110,6 @@ dependencies = [
  "num_cpus",
  "pin-project-lite 0.2.7",
  "slab",
-]
-
-[[package]]
-name = "tokio"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
-dependencies = [
- "autocfg",
- "pin-project-lite 0.2.7",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://darwinia.network/"
 license     = "GPL-3.0"
 name        = "darwinia"
 repository  = "https://github.com/darwinia-network/darwinia/"
-version     = "0.11.1"
+version     = "0.11.2"
 
 [[bin]]
 name = "darwinia"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,7 +7,7 @@ homepage    = "https://darwinia.network/"
 license     = "GPL-3.0"
 name        = "darwinia-cli"
 repository  = "https://github.com/darwinia-network/darwinia/"
-version     = "0.11.1"
+version     = "0.11.2"
 
 	[package.metadata.wasm-pack.profile.release]
 	# `wasm-opt` has some problems on linux, see

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://darwinia.network/"
 license     = "GPL-3.0"
 name        = "darwinia-primitives"
 repository  = "https://github.com/darwinia-network/darwinia/"
-version     = "0.11.1"
+version     = "0.11.2"
 
 [dependencies]
 # crates

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://darwinia.network/"
 license     = "GPL-3.0"
 name        = "darwinia-rpc"
 repository  = "https://github.com/darwinia-network/darwinia/"
-version     = "0.11.1"
+version     = "0.11.2"
 
 [dependencies]
 # crates

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://darwinia.network/"
 license     = "GPL-3.0"
 name        = "darwinia-runtime-common"
 repository  = "https://github.com/darwinia-network/darwinia/"
-version     = "0.11.1"
+version     = "0.11.2"
 
 [dependencies]
 # crates

--- a/runtime/crab/Cargo.toml
+++ b/runtime/crab/Cargo.toml
@@ -7,7 +7,7 @@ homepage    = "https://darwinia.network/"
 license     = "GPL-3.0"
 name        = "crab-runtime"
 repository  = "https://github.com/darwinia-network/darwinia/"
-version     = "0.11.1"
+version     = "0.11.2"
 
 [dependencies]
 # crates

--- a/runtime/crab/src/lib.rs
+++ b/runtime/crab/src/lib.rs
@@ -674,6 +674,7 @@ impl OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
 		// --- darwinia-network ---
 		use darwinia_header_mmr::NodeIndex;
 
+		log::info!("Migrate `DarwiniaHeaderMMR`...");
 		darwinia_header_mmr::migration::migrate(b"DarwiniaHeaderMMR");
 
 		assert!(migration::storage_key_iter::<NodeIndex, Hash, Identity>(
@@ -697,6 +698,7 @@ impl OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
 	}
 
 	fn on_runtime_upgrade() -> Weight {
+		log::info!("Migrate `DarwiniaHeaderMMR`...");
 		darwinia_header_mmr::migration::migrate(b"DarwiniaHeaderMMR");
 
 		let number = System::block_number();
@@ -715,6 +717,8 @@ impl OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
 		if old_to_remove != 0 {
 			for to_remove in old_to_remove..=new_to_remove_before_finalize {
 				<frame_system::BlockHash<Runtime>>::remove(to_remove);
+
+				log::info!("Pruned `BlockHash` of Block `{}`", to_remove);
 			}
 		}
 

--- a/runtime/crab/src/lib.rs
+++ b/runtime/crab/src/lib.rs
@@ -156,13 +156,13 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: sp_runtime::create_runtime_str!("Crab"),
 	impl_name: sp_runtime::create_runtime_str!("Darwinia Crab"),
 	authoring_version: 0,
-	spec_version: 1110,
+	spec_version: 1120,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,
 	#[cfg(feature = "disable-runtime-api")]
 	apis: sp_version::create_apis_vec![[]],
-	transaction_version: 5,
+	transaction_version: 6,
 };
 
 /// Native version.

--- a/runtime/darwinia/Cargo.toml
+++ b/runtime/darwinia/Cargo.toml
@@ -7,7 +7,7 @@ homepage    = "https://darwinia.network/"
 license     = "GPL-3.0"
 name        = "darwinia-runtime"
 repository  = "https://github.com/darwinia-network/darwinia/"
-version     = "0.11.1"
+version     = "0.11.2"
 
 [dependencies]
 # crates

--- a/runtime/darwinia/src/lib.rs
+++ b/runtime/darwinia/src/lib.rs
@@ -641,6 +641,7 @@ impl OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
 		// --- darwinia-network ---
 		use darwinia_header_mmr::NodeIndex;
 
+		log::info!("Migrate `DarwiniaHeaderMMR`...");
 		darwinia_header_mmr::migration::migrate(b"DarwiniaHeaderMMR");
 
 		assert!(migration::storage_key_iter::<NodeIndex, Hash, Identity>(
@@ -660,12 +661,23 @@ impl OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
 			&[]
 		));
 
+		log::info!("Migrate `EthereumRelay`...");
+		darwinia_ethereum_relay::migration::migrate(PARCEL);
+
+		log::info!("Migrate `EthereumRelayerGame`...");
+		darwinia_relayer_game::migration::migrate::<Runtime, EthereumRelayerGameInstance>();
+
 		Ok(())
 	}
 
 	fn on_runtime_upgrade() -> Weight {
+		log::info!("Migrate `DarwiniaHeaderMMR`...");
 		darwinia_header_mmr::migration::migrate(b"DarwiniaHeaderMMR");
+
+		log::info!("Migrate `EthereumRelay`...");
 		darwinia_ethereum_relay::migration::migrate(PARCEL);
+
+		log::info!("Migrate `EthereumRelayerGame`...");
 		darwinia_relayer_game::migration::migrate::<Runtime, EthereumRelayerGameInstance>();
 
 		RuntimeBlockWeights::get().max_block

--- a/runtime/darwinia/src/lib.rs
+++ b/runtime/darwinia/src/lib.rs
@@ -203,7 +203,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: sp_runtime::create_runtime_str!("Darwinia"),
 	impl_name: sp_runtime::create_runtime_str!("Darwinia"),
 	authoring_version: 0,
-	spec_version: 1110,
+	spec_version: 1120,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,


### PR DESCRIPTION
> https://github.com/darwinia-network/substrate-update-tracking/issues/22

## Versions
- For Substrate: from https://github.com/paritytech/substrate/commit/3f11019 to https://github.com/paritytech/substrate/commit/1d7f6e1
- For Polkadot: from [v0.9.1](https://github.com/paritytech/polkadot/releases/tag/v0.9.1) to [v0.9.2](https://github.com/paritytech/polkadot/releases/tag/v0.9.2)
- For darwinia-common:
  - [x] https://github.com/darwinia-network/darwinia-common/pull/644
  - [x] https://github.com/darwinia-network/darwinia-common/pull/648
  - [x] https://github.com/darwinia-network/darwinia-common/pull/652
  - [x] https://github.com/darwinia-network/darwinia-common/pull/654
  - [x] https://github.com/darwinia-network/darwinia-common/pull/686
  - [x] https://github.com/darwinia-network/darwinia-common/pull/703
  - [x] https://github.com/darwinia-network/darwinia-common/pull/708
  - [x] https://github.com/darwinia-network/darwinia-common/pull/718
  - [x] https://github.com/darwinia-network/darwinia-common/pull/729

## Migrations
> *v0.9.1 was released on May 13, 2021 and v0.9.2 was released May 21, 2021*

**According to [E1-runtimemigration](https://github.com/paritytech/substrate/pulls?q=is%3Apr+label%3AE1-runtimemigration+merged%3A%3E2021-05-12+is%3Aclosed+sort%3Aupdated-asc+) we got these migrations:**
- [x] https://github.com/paritytech/substrate/pull/8773 we don't have this pallet
- [x] https://github.com/paritytech/substrate/pull/8769 it's okay we never modify the `Scheduler` in `construct_runtime!`