### PR TITLE
Release `v0.12.4-2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "crab-runtime"
-version = "0.12.4"
+version = "0.12.4-2"
 dependencies = [
  "bp-crab",
  "bp-crab-parachain",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia"
-version = "0.12.4"
+version = "0.12.4-2"
 dependencies = [
  "darwinia-cli",
  "darwinia-node-service",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-cli"
-version = "0.12.4"
+version = "0.12.4-2"
 dependencies = [
  "darwinia-node-service",
  "darwinia-primitives",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-common-runtime"
-version = "0.12.4"
+version = "0.12.4-2"
 dependencies = [
  "bp-messages",
  "bridge-runtime-common",
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-node-service"
-version = "0.12.4"
+version = "0.12.4-2"
 dependencies = [
  "array-bytes",
  "crab-runtime",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-primitives"
-version = "0.12.4"
+version = "0.12.4-2"
 dependencies = [
  "darwinia-support",
  "parity-scale-codec",
@@ -1854,7 +1854,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-rpc"
-version = "0.12.4"
+version = "0.12.4-2"
 dependencies = [
  "crab-runtime",
  "darwinia-ethereum",
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-runtime"
-version = "0.12.4"
+version = "0.12.4-2"
 dependencies = [
  "array-bytes",
  "bp-crab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://darwinia.network"
 license     = "GPL-3.0"
 name        = "darwinia"
 repository  = "https://github.com/darwinia-network/darwinia"
-version     = "0.12.4"
+version     = "0.12.4-2"
 
 [[bin]]
 name = "darwinia"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,7 +7,7 @@ homepage    = "https://darwinia.network"
 license     = "GPL-3.0"
 name        = "darwinia-cli"
 repository  = "https://github.com/darwinia-network/darwinia"
-version     = "0.12.4"
+version     = "0.12.4-2"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://darwinia.network"
 license     = "GPL-3.0"
 name        = "darwinia-node-service"
 repository  = "https://github.com/darwinia-network/darwinia"
-version     = "0.12.4"
+version     = "0.12.4-2"
 
 [dependencies]
 # crates.io

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://darwinia.network"
 license     = "GPL-3.0"
 name        = "darwinia-primitives"
 repository  = "https://github.com/darwinia-network/darwinia"
-version     = "0.12.4"
+version     = "0.12.4-2"
 
 [dependencies]
 # crates.io

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://darwinia.network"
 license     = "GPL-3.0"
 name        = "darwinia-rpc"
 repository  = "https://github.com/darwinia-network/darwinia"
-version     = "0.12.4"
+version     = "0.12.4-2"
 
 [dependencies]
 # crates.io

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://darwinia.network"
 license     = "GPL-3.0"
 name        = "darwinia-common-runtime"
 repository  = "https://github.com/darwinia-network/darwinia"
-version     = "0.12.4"
+version     = "0.12.4-2"
 
 [dependencies]
 # crates.io

--- a/runtime/crab/Cargo.toml
+++ b/runtime/crab/Cargo.toml
@@ -7,7 +7,7 @@ homepage    = "https://darwinia.network"
 license     = "GPL-3.0"
 name        = "crab-runtime"
 repository  = "https://github.com/darwinia-network/darwinia"
-version     = "0.12.4"
+version     = "0.12.4-2"
 
 [dependencies]
 # crates.io

--- a/runtime/crab/src/lib.rs
+++ b/runtime/crab/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: sp_runtime::create_runtime_str!("Crab"),
 	impl_name: sp_runtime::create_runtime_str!("Darwinia Crab"),
 	authoring_version: 0,
-	spec_version: 12_4_1,
+	spec_version: 12_4_2,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,

--- a/runtime/darwinia/Cargo.toml
+++ b/runtime/darwinia/Cargo.toml
@@ -7,7 +7,7 @@ homepage    = "https://darwinia.network"
 license     = "GPL-3.0"
 name        = "darwinia-runtime"
 repository  = "https://github.com/darwinia-network/darwinia"
-version     = "0.12.4"
+version     = "0.12.4-2"
 
 [dependencies]
 # crates.io

--- a/runtime/darwinia/src/lib.rs
+++ b/runtime/darwinia/src/lib.rs
@@ -172,7 +172,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: sp_runtime::create_runtime_str!("Darwinia"),
 	impl_name: sp_runtime::create_runtime_str!("Darwinia"),
 	authoring_version: 0,
-	spec_version: 12_4_1,
+	spec_version: 12_4_2,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,


### PR DESCRIPTION
We could skip this upgrade for Crab.