### PR TITLE
Update IdProvider

### DIFF
--- a/node/src/service/mod.rs
+++ b/node/src/service/mod.rs
@@ -281,7 +281,7 @@ where
 		sc_service::Error,
 	>,
 {
-	let parachain_config = cumulus_client_service::prepare_node_config(parachain_config);
+	let mut parachain_config = cumulus_client_service::prepare_node_config(parachain_config);
 	let sc_service::PartialComponents {
 		backend,
 		client,
@@ -357,6 +357,8 @@ where
 		eth_rpc_config.eth_statuses_cache,
 		prometheus_registry.clone(),
 	));
+	// for ethereum-compatibility rpc.
+	parachain_config.rpc_id_provider = Some(Box::new(fc_rpc::EthereumSubIdProvider));
 	let rpc_builder = {
 		let client = client.clone();
 		let pool = transaction_pool.clone();
@@ -643,7 +645,7 @@ where
 /// Start a dev node which can seal instantly.
 /// !!! WARNING: DO NOT USE ELSEWHERE
 pub fn start_dev_node<RuntimeApi, Executor>(
-	config: sc_service::Configuration,
+	mut config: sc_service::Configuration,
 	eth_rpc_config: &crate::cli::EthRpcConfig,
 ) -> Result<sc_service::TaskManager, sc_service::error::Error>
 where
@@ -809,7 +811,8 @@ where
 		eth_rpc_config.eth_statuses_cache,
 		prometheus_registry,
 	));
-
+	// for ethereum-compatibility rpc.
+	config.rpc_id_provider = Some(Box::new(fc_rpc::EthereumSubIdProvider));
 	let rpc_extensions_builder = {
 		let client = client.clone();
 		let pool = transaction_pool.clone();


### PR DESCRIPTION
Before:

```sh
> {"jsonrpc":"2.0","id":1,"method":"eth_subscribe","params":["newHeads"]}
< {"jsonrpc":"2.0","result":"TifrJlysi9A4zkTs","id":1}
```

After:
```sh
> {"jsonrpc":"2.0","id":1,"method":"eth_subscribe","params":["newHeads"]}
< {"jsonrpc":"2.0","result":"0xaa2c8721fe4d8d3effb168e499d57c77","id":1}
```

See in the frontier example: https://github.com/paritytech/frontier/blob/polkadot-v0.9.37/template/node/src/service.rs#L345