### PR TITLE
Adjust weight to fee

### DIFF
--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -68,8 +68,9 @@ impl WeightToFeePolynomial for WeightToFee {
 	type Balance = Balance;
 
 	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-		let p = MILLIUNIT;
-		let q = 100 * Balance::from(ExtrinsicBaseWeight::get().ref_time());
+		let p = UNIT;
+		let q = 10 * Balance::from(ExtrinsicBaseWeight::get().ref_time());
+
 		smallvec::smallvec![WeightToFeeCoefficient {
 			degree: 1,
 			negative: false,

--- a/runtime/common/src/test.rs
+++ b/runtime/common/src/test.rs
@@ -494,18 +494,18 @@ macro_rules! impl_fee_tests {
 			}
 
 			#[test]
-			fn initial_gas_fee_is_correct() {
+			fn initial_evm_gas_fee_is_correct() {
 				ExtBuilder::default().build().execute_with(|| {
 					assert_eq!(TransactionPayment::next_fee_multiplier(), Multiplier::from(1u128));
 					assert_eq!(
 						TransactionPaymentGasPrice::min_gas_price().0,
-						U256::from(1_878_004_808u128)
+						U256::from(18_780_048_076_923u128)
 					);
 				})
 			}
 
 			#[test]
-			fn test_dynamic_fee_adjustment() {
+			fn test_evm_fee_adjustment() {
 				ExtBuilder::default().build().execute_with(|| {
 					let sim = |fullness: Perbill, num_blocks: u64| -> U256 {
 						let block_weight = NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT * fullness;
@@ -518,39 +518,75 @@ macro_rules! impl_fee_tests {
 						TransactionPaymentGasPrice::min_gas_price().0
 					};
 
-					assert_eq!(sim(Perbill::from_percent(0), 1), U256::from(1_877_969_595),);
-					assert_eq!(sim(Perbill::from_percent(25), 1), U256::from(1_877_969_595),);
-					assert_eq!(sim(Perbill::from_percent(50), 1), U256::from(1_878_004_808),);
-					assert_eq!(sim(Perbill::from_percent(100), 1), U256::from(1_878_110_448),);
+					assert_eq!(
+						sim(Perbill::from_percent(0), 1),
+						U256::from(18_779_695_954_322u128),
+					);
+					assert_eq!(
+						sim(Perbill::from_percent(25), 1),
+						U256::from(18_779_695_954_322u128),
+					);
+					assert_eq!(
+						sim(Perbill::from_percent(50), 1),
+						U256::from(18_780_048_076_923u128),
+					);
+					assert_eq!(
+						sim(Perbill::from_percent(100), 1),
+						U256::from(18_781_104_484_337u128),
+					);
 
 					// 1 "real" hour (at 12-second blocks)
-					assert_eq!(sim(Perbill::from_percent(0), 300), U256::from(1_867_575_734));
-					assert_eq!(sim(Perbill::from_percent(25), 300), U256::from(1_867_575_734),);
-					assert_eq!(sim(Perbill::from_percent(50), 300), U256::from(1_878_110_448),);
-					assert_eq!(sim(Perbill::from_percent(100), 300), U256::from(1_910_072_483),);
+					assert_eq!(
+						sim(Perbill::from_percent(0), 300),
+						U256::from(18_675_757_338_238u128)
+					);
+					assert_eq!(
+						sim(Perbill::from_percent(25), 300),
+						U256::from(18_675_757_338_238u128),
+					);
+					assert_eq!(
+						sim(Perbill::from_percent(50), 300),
+						U256::from(18_781_104_484_337u128),
+					);
+					assert_eq!(
+						sim(Perbill::from_percent(100), 300),
+						U256::from(19_100_724_834_341u128),
+					);
 
 					// 1 "real" day (at 12-second blocks)
-					assert_eq!(sim(Perbill::from_percent(0), 7200), U256::from(1_668_860_721u128),);
-					assert_eq!(sim(Perbill::from_percent(25), 7200), U256::from(1_668_860_721u128),);
-					assert_eq!(sim(Perbill::from_percent(50), 7200), U256::from(1_910_072_483u128));
+					assert_eq!(
+						sim(Perbill::from_percent(0), 7200),
+						U256::from(16_688_607_212_670u128),
+					);
+					assert_eq!(
+						sim(Perbill::from_percent(25), 7200),
+						U256::from(16_688_607_212_670u128),
+					);
+					assert_eq!(
+						sim(Perbill::from_percent(50), 7200),
+						U256::from(19_100_724_834_341u128)
+					);
 					assert_eq!(
 						sim(Perbill::from_percent(100), 7200),
-						U256::from(2_863_776_449u128),
+						U256::from(28_637_764_490_907u128),
 					);
 
 					// 7 "real" day (at 12-second blocks)
-					assert_eq!(sim(Perbill::from_percent(0), 50400), U256::from(1_113_091_401u128),);
+					assert_eq!(
+						sim(Perbill::from_percent(0), 50400),
+						U256::from(11_130_914_014_528u128),
+					);
 					assert_eq!(
 						sim(Perbill::from_percent(25), 50400),
-						U256::from(1_113_091_401u128),
+						U256::from(11_130_914_014_528u128),
 					);
 					assert_eq!(
 						sim(Perbill::from_percent(50), 50400),
-						U256::from(2_863_776_449u128)
+						U256::from(28_637_764_490_907u128)
 					);
 					assert_eq!(
 						sim(Perbill::from_percent(100), 50400),
-						U256::from(48_771_259_233u128),
+						U256::from(487_712_592_259_520u128),
 					);
 				})
 			}

--- a/runtime/pangolin/src/pallets/evm.rs
+++ b/runtime/pangolin/src/pallets/evm.rs
@@ -142,7 +142,7 @@ impl pallet_evm::FeeCalculator for TransactionPaymentGasPrice {
 					),
 				)
 				.into(),
-			frame_support::weights::Weight::zero(),
+			<Runtime as frame_system::Config>::DbWeight::get().reads(1),
 		)
 	}
 }

--- a/runtime/pangoro/src/pallets/evm.rs
+++ b/runtime/pangoro/src/pallets/evm.rs
@@ -140,7 +140,7 @@ impl pallet_evm::FeeCalculator for TransactionPaymentGasPrice {
 					),
 				)
 				.into(),
-			frame_support::weights::Weight::zero(),
+			<Runtime as frame_system::Config>::DbWeight::get().reads(1),
 		)
 	}
 }

--- a/tests/ethereum/test-balance.ts
+++ b/tests/ethereum/test-balance.ts
@@ -7,7 +7,7 @@ import { HOST_HTTP_URL, FAITH, FAITH_P, ETHAN, DEFAULT_GAS } from "../config";
 const web3 = new Web3(HOST_HTTP_URL);
 describe("Test balances", () => {
 	const VALUE = "0x200";
-	const GAS_PRICE = "0x77359400"; // 2000000000
+	const GAS_PRICE = "0x12309ce54000"; // 20_000_000_000_000
 
 	let init_from;
 	let init_to;


### PR DESCRIPTION
After conducting tests and research, I have determined that the appropriate parameters for our networks are `0.1 RING/CRAB` per base extrinsic. 

For instance, to perform a runtime upgrade by uploading a WASM file of approximately `1.3 MB` in size, we will require `500 UNIT` for the extrinsic. 

This change is inspired by #1050.