### PR TITLE
Add data path and grant to darwinia user

### DIFF
--- a/.maintain/docker/Dockerfile
+++ b/.maintain/docker/Dockerfile
@@ -12,7 +12,9 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
     && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /data \
     && chown -R $USERNAME:$USERNAME /home/$USERNAME \
+    && chown -R $USERNAME:$USERNAME /data \
     && ln -s /home/$USERNAME/darwinia-nodes/darwinia /usr/local/bin/darwinia
 
 USER $USERNAME


### PR DESCRIPTION
fix #1095 


Normally the node data store to `/data` path. e.g. https://github.com/paritytech/polkadot/blob/dbae30efe080a1d41fe54ef4da8af47614c9ca93/scripts/ci/dockerfiles/polkadot_injected_release.Dockerfile#L39-L40

Because we use no-root user in docker image, we should set data permission to custom user. otherwise there will be no permission to create the directory.

IMPORTANT:
For docker image users, the path to mount data must be bound to `/data` or `/home/darwinia`

e.g.

```
version: "3.7"
services:
  node-pangolin2:
    container_name: node-pangolin2
    image: ghcr.io/darwinia-network/darwinia:pango-6021
    restart: always
    volumes:
      - pangolin2-data:/home/darwinia/data
    command:
      - --base-path=/home/darwinia/data
      - --chain=pangolin
      - --collator
      - --pruning=archive
```

or

```
version: "3.7"
services:
  node-pangolin2:
    container_name: node-pangolin2
    image: ghcr.io/darwinia-network/darwinia:pango-6021
    restart: always
    volumes:
      - pangolin2-data:/data
    command:
      - --base-path=/data
      - --chain=pangolin
      - --collator
      - --pruning=archive
```

https://github.com/darwinia-network/darwinia/actions/runs/4663293655

