### PR TITLE
Double Kusama `MaxBridgedHeaderSize`

### DIFF
--- a/runtime/darwinia/src/pallets/bridge_grandpa.rs
+++ b/runtime/darwinia/src/pallets/bridge_grandpa.rs
@@ -27,7 +27,8 @@ impl pallet_bridge_grandpa::Config<WithKusamaGrandpa> for Runtime {
 	type BridgedChain = bp_crab::DarwiniaLike;
 	type HeadersToKeep = KusamaHeadersToKeep;
 	type MaxBridgedAuthorities = ConstU32<100_000>;
-	// Kusama chain have 1000 validators. update to 65536 * 2
+	// Kusama chain currently has 1000 validators.
+	// Double the default value `65536` here.
 	type MaxBridgedHeaderSize = ConstU32<131_072>;
 	type MaxRequests = ConstU32<50>;
 	type WeightInfo = weights::pallet_bridge_grandpa::WeightInfo<Self>;

--- a/runtime/darwinia/src/pallets/bridge_grandpa.rs
+++ b/runtime/darwinia/src/pallets/bridge_grandpa.rs
@@ -27,7 +27,7 @@ impl pallet_bridge_grandpa::Config<WithKusamaGrandpa> for Runtime {
 	type BridgedChain = bp_crab::DarwiniaLike;
 	type HeadersToKeep = KusamaHeadersToKeep;
 	type MaxBridgedAuthorities = ConstU32<100_000>;
-	type MaxBridgedHeaderSize = ConstU32<65536>;
+	type MaxBridgedHeaderSize = ConstU32<65536 * 2>;
 	type MaxRequests = ConstU32<50>;
 	type WeightInfo = weights::pallet_bridge_grandpa::WeightInfo<Self>;
 }

--- a/runtime/darwinia/src/pallets/bridge_grandpa.rs
+++ b/runtime/darwinia/src/pallets/bridge_grandpa.rs
@@ -27,7 +27,7 @@ impl pallet_bridge_grandpa::Config<WithKusamaGrandpa> for Runtime {
 	type BridgedChain = bp_crab::DarwiniaLike;
 	type HeadersToKeep = KusamaHeadersToKeep;
 	type MaxBridgedAuthorities = ConstU32<100_000>;
-	type MaxBridgedHeaderSize = ConstU32<65536 * 2>;
+	type MaxBridgedHeaderSize = ConstU32<131_072>; // 65536 * 2
 	type MaxRequests = ConstU32<50>;
 	type WeightInfo = weights::pallet_bridge_grandpa::WeightInfo<Self>;
 }

--- a/runtime/darwinia/src/pallets/bridge_grandpa.rs
+++ b/runtime/darwinia/src/pallets/bridge_grandpa.rs
@@ -27,7 +27,8 @@ impl pallet_bridge_grandpa::Config<WithKusamaGrandpa> for Runtime {
 	type BridgedChain = bp_crab::DarwiniaLike;
 	type HeadersToKeep = KusamaHeadersToKeep;
 	type MaxBridgedAuthorities = ConstU32<100_000>;
-	type MaxBridgedHeaderSize = ConstU32<131_072>; // 65536 * 2
+	// Kusama chain have 1000 validators. update to 65536 * 2
+	type MaxBridgedHeaderSize = ConstU32<131_072>;
 	type MaxRequests = ConstU32<50>;
 	type WeightInfo = weights::pallet_bridge_grandpa::WeightInfo<Self>;
 }


### PR DESCRIPTION
fix kusama -> darwinia grandpa relay
https://darwinia.subscan.io/extrinsic/0x46bd4ea2960b879ceaecbc07ecf875241254887254923f4af0c1cf97e01ecf3b

Related:
https://github.com/darwinia-network/darwinia-messages-substrate/blob/5e5d637438a90f8f3eb1eee5c442f51916acb7ba/modules/grandpa/src/lib.rs#L211-L219
https://github.com/darwinia-network/darwinia/blob/d4f5d5d02594c8704f0ff974fb58889435b1c52f/runtime/darwinia/src/pallets/bridge_grandpa.rs#L30
