### PR TITLE
Release `v6.2.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,7 +1480,7 @@ dependencies = [
 
 [[package]]
 name = "crab-runtime"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "array-bytes 6.1.0",
  "bp-darwinia-core",
@@ -2430,7 +2430,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "array-bytes 6.1.0",
  "async-trait",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-account-migration"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "array-bytes 6.1.0",
  "darwinia-deposit",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-common-runtime"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "account",
  "bp-darwinia-core",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-deposit"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "darwinia-staking-traits",
  "dc-inflation",
@@ -2580,7 +2580,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-ecdsa-authority"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "array-bytes 6.1.0",
  "dc-primitives",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-message-gadget"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "array-bytes 6.1.0",
  "frame-support",
@@ -2618,7 +2618,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-message-transact"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "array-bytes 6.1.0",
  "bp-message-dispatch",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-precompile-assets"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-precompile-bls12-381"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -2686,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-precompile-deposit"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "darwinia-deposit",
  "fp-evm",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-precompile-staking"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "darwinia-deposit",
  "darwinia-staking",
@@ -2727,7 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-precompile-state-storage"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-runtime"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "array-bytes 6.1.0",
  "bp-darwinia-core",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-staking"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "darwinia-deposit",
  "darwinia-staking-traits",
@@ -2877,7 +2877,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-staking-traits"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2925,7 +2925,7 @@ dependencies = [
 
 [[package]]
 name = "dc-inflation"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "dc-types",
  "primitive-types 0.12.1",
@@ -2935,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "dc-primitives"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "account",
  "dc-types",
@@ -2945,7 +2945,7 @@ dependencies = [
 
 [[package]]
 name = "dc-types"
-version = "6.2.0"
+version = "6.2.1"
 
 [[package]]
 name = "der"
@@ -8191,7 +8191,7 @@ dependencies = [
 
 [[package]]
 name = "pangolin-runtime"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "array-bytes 6.1.0",
  "bp-darwinia-core",
@@ -8297,7 +8297,7 @@ dependencies = [
 
 [[package]]
 name = "pangoro-runtime"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "array-bytes 6.1.0",
  "bp-darwinia-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition    = "2021"
 homepage   = "https://darwinia.network"
 license    = "GPL-3.0"
 repository = "https://github.com/darwinia-network/darwinia"
-version    = "6.2.0"
+version    = "6.2.1"
 
 [workspace.dependencies]
 # crates.io

--- a/runtime/crab/src/lib.rs
+++ b/runtime/crab/src/lib.rs
@@ -85,7 +85,7 @@ pub const VERSION: sp_version::RuntimeVersion = sp_version::RuntimeVersion {
 	spec_name: sp_runtime::create_runtime_str!("Crab2"),
 	impl_name: sp_runtime::create_runtime_str!("DarwiniaOfficialRust"),
 	authoring_version: 0,
-	spec_version: 6_2_0_0,
+	spec_version: 6_2_1_0,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,

--- a/runtime/darwinia/src/lib.rs
+++ b/runtime/darwinia/src/lib.rs
@@ -84,7 +84,7 @@ pub const VERSION: sp_version::RuntimeVersion = sp_version::RuntimeVersion {
 	spec_name: sp_runtime::create_runtime_str!("Darwinia2"),
 	impl_name: sp_runtime::create_runtime_str!("DarwiniaOfficialRust"),
 	authoring_version: 0,
-	spec_version: 6_2_0_0,
+	spec_version: 6_2_1_0,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,

--- a/runtime/darwinia/src/pallets/bridge_grandpa.rs
+++ b/runtime/darwinia/src/pallets/bridge_grandpa.rs
@@ -27,7 +27,9 @@ impl pallet_bridge_grandpa::Config<WithKusamaGrandpa> for Runtime {
 	type BridgedChain = bp_crab::DarwiniaLike;
 	type HeadersToKeep = KusamaHeadersToKeep;
 	type MaxBridgedAuthorities = ConstU32<100_000>;
-	type MaxBridgedHeaderSize = ConstU32<65536>;
+	// Kusama chain currently has 1000 validators.
+	// Double the default value `65536` here.
+	type MaxBridgedHeaderSize = ConstU32<131_072>;
 	type MaxRequests = ConstU32<50>;
 	type WeightInfo = weights::pallet_bridge_grandpa::WeightInfo<Self>;
 }

--- a/runtime/pangolin/src/lib.rs
+++ b/runtime/pangolin/src/lib.rs
@@ -86,7 +86,7 @@ pub const VERSION: sp_version::RuntimeVersion = sp_version::RuntimeVersion {
 	spec_name: sp_runtime::create_runtime_str!("Pangolin2"),
 	impl_name: sp_runtime::create_runtime_str!("DarwiniaOfficialRust"),
 	authoring_version: 0,
-	spec_version: 6_2_0_0,
+	spec_version: 6_2_1_0,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,

--- a/runtime/pangoro/src/lib.rs
+++ b/runtime/pangoro/src/lib.rs
@@ -85,7 +85,7 @@ pub const VERSION: sp_version::RuntimeVersion = sp_version::RuntimeVersion {
 	spec_name: sp_runtime::create_runtime_str!("Pangoro2"),
 	impl_name: sp_runtime::create_runtime_str!("DarwiniaOfficialRust"),
 	authoring_version: 0,
-	spec_version: 6_2_0_0,
+	spec_version: 6_2_1_0,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,

--- a/tool/state-processor/Cargo.lock
+++ b/tool/state-processor/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "dc-types"
-version = "6.2.0"
+version = "6.2.1"
 
 [[package]]
 name = "derive_more"


### PR DESCRIPTION
This release is based on `v6.2.0`.
Avoid adding the un-tested evm tracing code to release.