### PR TITLE
Release runtime override

### DIFF
--- a/.github/workflows/runtime-override.yml
+++ b/.github/workflows/runtime-override.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           TAG=$(echo ${{ github.ref }} | sed 's!.*/\(.*\)!\1!')
           curl -XPOST \
-            -H "Authorization:Bearer ${{ secrets.WASM_RUNTIME_OVERRIDES }}" \
+            -H "Authorization:Bearer ${{ secrets.GH_TKN_DARWINIA }}" \
             -H "Accept:application/vnd.github+json" \
             "https://api.github.com/repos/darwinia-network/wasm-runtime-overrides/dispatches" \
             -d '{"event_type":"create","client_payload":{"release":"testnets","ref":"'"${TAG}"'"}}'

--- a/.github/workflows/runtime-override.yml
+++ b/.github/workflows/runtime-override.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Runtime override
         run: |
           TAG=$(echo ${{ github.ref }} | sed 's!.*/\(.*\)!\1!')
-          curl -X POST \
-             -H "Authorization:Bearer ${{ secrets.WASM_RUNTIME_OVERRIDES }}" \
-             -H "Accept:application/vnd.github+json" \
-             "https://api.github.com/repos/darwinia-network/darwinia/dispatches" \
-             -d '{"event_type":"created","client_payload":{"release":"mainnets","ref":"'"${TAG}"'"}}'
+          curl -XPOST \
+            -H "Authorization:Bearer ${{ secrets.WASM_RUNTIME_OVERRIDES }}" \
+            -H "Accept:application/vnd.github+json" \
+            "https://api.github.com/repos/darwinia-network/wasm-runtime-overrides/dispatches" \
+            -d '{"event_type":"create","client_payload":{"release":"mainnets","ref":"'"${TAG}"'"}}'
 
   runtime-override-testnets:
     name: Runtime override
@@ -29,8 +29,8 @@ jobs:
       - name: Runtime override
         run: |
           TAG=$(echo ${{ github.ref }} | sed 's!.*/\(.*\)!\1!')
-          curl -X POST \
-             -H "Authorization:Bearer ${{ secrets.WASM_RUNTIME_OVERRIDES }}" \
-             -H "Accept:application/vnd.github+json" \
-             "https://api.github.com/repos/darwinia-network/darwinia/dispatches" \
-             -d '{"event_type":"created","client_payload":{"release":"testnets","ref":"'"${TAG}"'"}}'
+          curl -XPOST \
+            -H "Authorization:Bearer ${{ secrets.WASM_RUNTIME_OVERRIDES }}" \
+            -H "Accept:application/vnd.github+json" \
+            "https://api.github.com/repos/darwinia-network/wasm-runtime-overrides/dispatches" \
+            -d '{"event_type":"create","client_payload":{"release":"testnets","ref":"'"${TAG}"'"}}'

--- a/.github/workflows/runtime-override.yml
+++ b/.github/workflows/runtime-override.yml
@@ -1,0 +1,36 @@
+name: Runtime override
+
+on:
+  push:
+    tags:
+      - "v*"
+      - "pango*"
+
+jobs:
+  runtime-override-mainnets:
+    name: Runtime override
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Runtime override
+        run: |
+          TAG=$(echo ${{ github.ref }} | sed 's!.*/\(.*\)!\1!')
+          curl -X POST \
+             -H "Authorization:Bearer ${{ secrets.WASM_RUNTIME_OVERRIDES }}" \
+             -H "Accept:application/vnd.github+json" \
+             "https://api.github.com/repos/darwinia-network/darwinia/dispatches" \
+             -d '{"event_type":"created","client_payload":{"release":"mainnets","ref":"'"${TAG}"'"}}'
+
+  runtime-override-testnets:
+    name: Runtime override
+    if: startsWith(github.ref, 'refs/tags/pango')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Runtime override
+        run: |
+          TAG=$(echo ${{ github.ref }} | sed 's!.*/\(.*\)!\1!')
+          curl -X POST \
+             -H "Authorization:Bearer ${{ secrets.WASM_RUNTIME_OVERRIDES }}" \
+             -H "Accept:application/vnd.github+json" \
+             "https://api.github.com/repos/darwinia-network/darwinia/dispatches" \
+             -d '{"event_type":"created","client_payload":{"release":"testnets","ref":"'"${TAG}"'"}}'

--- a/.github/workflows/runtime-override.yml
+++ b/.github/workflows/runtime-override.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           TAG=$(echo ${{ github.ref }} | sed 's!.*/\(.*\)!\1!')
           curl -XPOST \
-            -H "Authorization:Bearer ${{ secrets.WASM_RUNTIME_OVERRIDES }}" \
+            -H "Authorization:Bearer ${{ secrets.GH_TKN_DARWINIA }}" \
             -H "Accept:application/vnd.github+json" \
             "https://api.github.com/repos/darwinia-network/wasm-runtime-overrides/dispatches" \
             -d '{"event_type":"create","client_payload":{"release":"mainnets","ref":"'"${TAG}"'"}}'


### PR DESCRIPTION
When a new tag gets created, this will trigger a release action at https://github.com/darwinia-network/wasm-runtime-overrides.