### PR TITLE
Fix compile warnings

### DIFF
--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -912,6 +912,7 @@ fn set_default_ss58_version(chain_spec: &dyn IdentifyVariant) {
 	crypto::set_default_ss58_version(ss58_version);
 }
 
+#[cfg(any(feature = "runtime-benchmarks", feature = "try-runtime"))]
 fn ensure_dev(spec: &dyn IdentifyVariant) -> Result<()> {
 	if spec.is_dev() {
 		Ok(())

--- a/runtime/common/src/xcm_configs.rs
+++ b/runtime/common/src/xcm_configs.rs
@@ -125,7 +125,7 @@ impl<AccountId: From<[u8; 20]> + Into<[u8; 20]> + Clone> Convert<MultiLocation, 
 	for Account20Hash<AccountId>
 {
 	fn convert_ref(location: impl Borrow<MultiLocation>) -> Result<AccountId, ()> {
-		let hash: [u8; 32] = ("multiloc", location.borrow()).borrow().using_encoded(blake2_256);
+		let hash: [u8; 32] = ("multiloc", location.borrow()).using_encoded(blake2_256);
 		let mut account_id = [0u8; 20];
 		account_id.copy_from_slice(&hash[0..20]);
 		Ok(account_id.into())


### PR DESCRIPTION
```sh
warning: using `.borrow()` on a double reference, which returns `&(&str, &xcm::v3::MultiLocation)` instead of borrowing the inner type
   --> runtime/common/src/xcm_configs.rs:128:55
    |
128 |         let hash: [u8; 32] = ("multiloc", location.borrow()).borrow().using_encoded(blake2_256);
    |                                                             ^^^^^^^^^
    |
    = note: `#[warn(suspicious_double_ref_op)]` on by default

warning: `darwinia-common-runtime` (lib) generated 1 warning
    Checking darwinia v6.3.4 (/home/bear/coding/rust-space/darwinia/node)
    Finished release [optimized] target(s) in 3.00s
```

---

```sh
warning: function `ensure_dev` is never used
   --> node/src/command.rs:915:4
    |
915 | fn ensure_dev(spec: &dyn IdentifyVariant) -> Result<()> {
    |    ^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: `darwinia` (bin "darwinia") generated 1 warning
    Finished release [optimized] target(s) in 10m 42s
```