### PR TITLE
Add `MaxCommission` and `CommissionUpdated`

### DIFF
--- a/pallet/account-migration/src/mock.rs
+++ b/pallet/account-migration/src/mock.rs
@@ -168,6 +168,7 @@ impl darwinia_deposit::Config for Runtime {
 impl darwinia_staking::Config for Runtime {
 	type Deposit = Deposit;
 	type Kton = Dummy;
+	type MaxCommission = ();
 	type MaxDeposits = ();
 	type MaxUnstakings = ();
 	type MinStakingDuration = ();

--- a/pallet/staking/src/mock.rs
+++ b/pallet/staking/src/mock.rs
@@ -246,10 +246,12 @@ impl darwinia_staking::Stake for KtonStaking {
 }
 frame_support::parameter_types! {
 	pub const PayoutFraction: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(40);
+	pub const MaxCommission: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(99);
 }
 impl darwinia_staking::Config for Runtime {
 	type Deposit = Deposit;
 	type Kton = KtonStaking;
+	type MaxCommission = MaxCommission;
 	type MaxDeposits = <Self as darwinia_deposit::Config>::MaxDeposits;
 	type MaxUnstakings = frame_support::traits::ConstU32<16>;
 	type MinStakingDuration = frame_support::traits::ConstU64<3>;

--- a/pallet/staking/src/mock.rs
+++ b/pallet/staking/src/mock.rs
@@ -245,8 +245,8 @@ impl darwinia_staking::Stake for KtonStaking {
 	}
 }
 frame_support::parameter_types! {
-	pub const PayoutFraction: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(40);
 	pub const MaxCommission: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(99);
+	pub const PayoutFraction: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(40);
 }
 impl darwinia_staking::Config for Runtime {
 	type Deposit = Deposit;

--- a/pallet/staking/src/tests.rs
+++ b/pallet/staking/src/tests.rs
@@ -357,12 +357,17 @@ fn collect_should_work() {
 		assert!(Staking::collator_of(1).is_none());
 		assert_ok!(Staking::stake(RuntimeOrigin::signed(1), UNIT, 0, Vec::new()));
 
-		(0..=100).for_each(|c| {
+		(0..=99).for_each(|c| {
 			let c = Perbill::from_percent(c);
 
 			assert_ok!(Staking::collect(RuntimeOrigin::signed(1), c));
 			assert_eq!(Staking::collator_of(1).unwrap(), c);
 		});
+
+		assert_noop!(
+			Staking::collect(RuntimeOrigin::signed(1), Perbill::from_percent(100)),
+			<Error<Runtime>>::CommissionTooHigh
+		);
 	});
 }
 

--- a/precompile/staking/src/mock.rs
+++ b/precompile/staking/src/mock.rs
@@ -230,9 +230,13 @@ impl darwinia_staking::Stake for KtonStaking {
 	}
 }
 
+frame_support::parameter_types! {
+	pub const MaxCommission: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(99);
+}
 impl darwinia_staking::Config for TestRuntime {
 	type Deposit = Deposit;
 	type Kton = KtonStaking;
+	type MaxCommission = MaxCommission;
 	type MaxDeposits = <Self as darwinia_deposit::Config>::MaxDeposits;
 	type MaxUnstakings = frame_support::traits::ConstU32<16>;
 	type MinStakingDuration = frame_support::traits::ConstU64<3>;

--- a/runtime/crab/src/pallets/staking.rs
+++ b/runtime/crab/src/pallets/staking.rs
@@ -69,12 +69,14 @@ impl darwinia_staking::Stake for KtonStaking {
 }
 
 frame_support::parameter_types! {
+	pub const MaxCommission: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(30);
 	pub const PayoutFraction: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(40);
 }
 
 impl darwinia_staking::Config for Runtime {
 	type Deposit = Deposit;
 	type Kton = KtonStaking;
+	type MaxCommission = MaxCommission;
 	type MaxDeposits = <Self as darwinia_deposit::Config>::MaxDeposits;
 	type MaxUnstakings = ConstU32<16>;
 	type MinStakingDuration = MinStakingDuration;

--- a/runtime/darwinia/src/pallets/staking.rs
+++ b/runtime/darwinia/src/pallets/staking.rs
@@ -69,12 +69,14 @@ impl darwinia_staking::Stake for KtonStaking {
 }
 
 frame_support::parameter_types! {
+	pub const MaxCommission: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(30);
 	pub const PayoutFraction: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(40);
 }
 
 impl darwinia_staking::Config for Runtime {
 	type Deposit = Deposit;
 	type Kton = KtonStaking;
+	type MaxCommission = MaxCommission;
 	type MaxDeposits = <Self as darwinia_deposit::Config>::MaxDeposits;
 	type MaxUnstakings = ConstU32<16>;
 	type MinStakingDuration = MinStakingDuration;

--- a/runtime/pangolin/src/pallets/staking.rs
+++ b/runtime/pangolin/src/pallets/staking.rs
@@ -67,12 +67,14 @@ impl darwinia_staking::Stake for KtonStaking {
 }
 
 frame_support::parameter_types! {
+	pub const MaxCommission: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(30);
 	pub const PayoutFraction: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(40);
 }
 
 impl darwinia_staking::Config for Runtime {
 	type Deposit = Deposit;
 	type Kton = KtonStaking;
+	type MaxCommission = MaxCommission;
 	type MaxDeposits = <Self as darwinia_deposit::Config>::MaxDeposits;
 	type MaxUnstakings = ConstU32<16>;
 	type MinStakingDuration = ConstU32<{ 10 * MINUTES }>;

--- a/runtime/pangoro/src/pallets/staking.rs
+++ b/runtime/pangoro/src/pallets/staking.rs
@@ -67,12 +67,14 @@ impl darwinia_staking::Stake for KtonStaking {
 }
 
 frame_support::parameter_types! {
+	pub const MaxCommission: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(30);
 	pub const PayoutFraction: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(40);
 }
 
 impl darwinia_staking::Config for Runtime {
 	type Deposit = Deposit;
 	type Kton = KtonStaking;
+	type MaxCommission = MaxCommission;
 	type MaxDeposits = <Self as darwinia_deposit::Config>::MaxDeposits;
 	type MaxUnstakings = ConstU32<16>;
 	type MinStakingDuration = ConstU32<{ 10 * MINUTES }>;


### PR DESCRIPTION
Introduce runtime configuration `MaxCommission`.

Introduce runtime event `CommissionUpdated`.

The maximum commission for all networks is set at 30%.