### PR TITLE
Update dispatch filter

### DIFF
--- a/runtime/common/src/test.rs
+++ b/runtime/common/src/test.rs
@@ -486,17 +486,15 @@ macro_rules! impl_evm_tests {
 			}
 
 			#[test]
-			fn dispatch_validator_works() {
+			fn dispatch_validator_filter_runtime_calls() {
 				ExtBuilder::default().build().execute_with(|| {
 					assert!(DarwiniaDispatchValidator::validate_before_dispatch(
-						// normal account
 						&H160::default().into(),
 						&RuntimeCall::System(frame_system::Call::remark { remark: vec![] })
 					)
 					.is_none());
 
 					assert!(DarwiniaDispatchValidator::validate_before_dispatch(
-						// normal account
 						&H160::default().into(),
 						// forbidden call
 						&RuntimeCall::EVM(pallet_evm::Call::call {
@@ -510,6 +508,32 @@ macro_rules! impl_evm_tests {
 							nonce: None,
 							access_list: vec![],
 						})
+					)
+					.is_some());
+				});
+			}
+
+			#[test]
+			fn dispatch_validator_filter_dispatch_class() {
+				ExtBuilder::default().build().execute_with(|| {
+					// Default class
+					assert!(DarwiniaDispatchValidator::validate_before_dispatch(
+						&H160::default().into(),
+						&RuntimeCall::System(frame_system::Call::remark { remark: vec![] })
+					)
+					.is_none());
+
+					// Operational class
+					assert!(DarwiniaDispatchValidator::validate_before_dispatch(
+						&H160::default().into(),
+						&RuntimeCall::System(frame_system::Call::set_heap_pages { pages: 20 })
+					)
+					.is_none());
+
+					// Mandatory class
+					assert!(DarwiniaDispatchValidator::validate_before_dispatch(
+						&H160::default().into(),
+						&RuntimeCall::Timestamp(pallet_timestamp::Call::set { now: 100 })
 					)
 					.is_some());
 				});

--- a/runtime/crab/src/pallets/evm.rs
+++ b/runtime/crab/src/pallets/evm.rs
@@ -202,7 +202,7 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 					"These pallet's calls are not allowed to be called from precompile.".into(),
 				),
 			})
-		} else if info.pays_fee == Pays::Yes || info.class == DispatchClass::Mandatory {
+		} else if info.pays_fee == Pays::No || info.class == DispatchClass::Mandatory {
 			Some(fp_evm::PrecompileFailure::Error {
 				exit_status: ExitError::Other("Permission denied calls".into()),
 			})

--- a/runtime/crab/src/pallets/evm.rs
+++ b/runtime/crab/src/pallets/evm.rs
@@ -194,7 +194,9 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 				| RuntimeCall::MessageTransact(..)
 		) {
 			Some(fp_evm::PrecompileFailure::Error {
-				exit_status: ExitError::Other("These pallet's calls are forbidden".into()),
+				exit_status: ExitError::Other(
+					"These pallet's calls are not allowed to be called from precompile.".into(),
+				),
 			})
 		} else {
 			<() as DispatchValidateT<AccountId, RuntimeCall>>::validate_before_dispatch(

--- a/runtime/crab/src/pallets/evm.rs
+++ b/runtime/crab/src/pallets/evm.rs
@@ -18,6 +18,8 @@
 
 // darwinia
 use crate::*;
+// substrate
+use frame_support::dispatch::{DispatchClass, GetDispatchInfo, Pays};
 // frontier
 use pallet_evm::{ExitError, IsPrecompileResult, Precompile};
 use pallet_evm_precompile_dispatch::DispatchValidateT;
@@ -182,13 +184,14 @@ fn addr(a: u64) -> sp_core::H160 {
 pub struct DarwiniaDispatchValidator;
 impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 	fn validate_before_dispatch(
-		origin: &AccountId,
+		_origin: &AccountId,
 		call: &RuntimeCall,
 	) -> Option<fp_evm::PrecompileFailure> {
+		let info = call.get_dispatch_info();
+
 		if matches!(
 			call,
 			RuntimeCall::Assets(..)
-				| RuntimeCall::Vesting(..)
 				| RuntimeCall::Ethereum(..)
 				| RuntimeCall::EVM(..)
 				| RuntimeCall::MessageTransact(..)
@@ -198,10 +201,12 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 					"These pallet's calls are not allowed to be called from precompile.".into(),
 				),
 			})
+		} else if info.pays_fee != Pays::Yes || info.class == DispatchClass::Mandatory {
+			Some(fp_evm::PrecompileFailure::Error {
+				exit_status: ExitError::Other("Permission denied calls".into()),
+			})
 		} else {
-			<() as DispatchValidateT<AccountId, RuntimeCall>>::validate_before_dispatch(
-				origin, call,
-			)
+			None
 		}
 	}
 }

--- a/runtime/crab/src/pallets/evm.rs
+++ b/runtime/crab/src/pallets/evm.rs
@@ -192,6 +192,7 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 		if matches!(
 			call,
 			RuntimeCall::Assets(..)
+				| RuntimeCall::Vesting(..)
 				| RuntimeCall::Ethereum(..)
 				| RuntimeCall::EVM(..)
 				| RuntimeCall::MessageTransact(..)

--- a/runtime/crab/src/pallets/evm.rs
+++ b/runtime/crab/src/pallets/evm.rs
@@ -202,7 +202,7 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 					"These pallet's calls are not allowed to be called from precompile.".into(),
 				),
 			})
-		} else if info.pays_fee != Pays::Yes || info.class == DispatchClass::Mandatory {
+		} else if info.pays_fee == Pays::Yes || info.class == DispatchClass::Mandatory {
 			Some(fp_evm::PrecompileFailure::Error {
 				exit_status: ExitError::Other("Permission denied calls".into()),
 			})

--- a/runtime/darwinia/src/pallets/evm.rs
+++ b/runtime/darwinia/src/pallets/evm.rs
@@ -201,7 +201,7 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 					"These pallet's calls are not allowed to be called from precompile.".into(),
 				),
 			})
-		} else if info.pays_fee != Pays::Yes || info.class == DispatchClass::Mandatory {
+		} else if info.pays_fee == Pays::Yes || info.class == DispatchClass::Mandatory {
 			Some(fp_evm::PrecompileFailure::Error {
 				exit_status: ExitError::Other("Permission denied calls".into()),
 			})

--- a/runtime/darwinia/src/pallets/evm.rs
+++ b/runtime/darwinia/src/pallets/evm.rs
@@ -191,6 +191,7 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 		if matches!(
 			call,
 			RuntimeCall::Assets(..)
+				| RuntimeCall::Vesting(..)
 				| RuntimeCall::Ethereum(..)
 				| RuntimeCall::EVM(..)
 				| RuntimeCall::MessageTransact(..)

--- a/runtime/darwinia/src/pallets/evm.rs
+++ b/runtime/darwinia/src/pallets/evm.rs
@@ -201,7 +201,7 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 					"These pallet's calls are not allowed to be called from precompile.".into(),
 				),
 			})
-		} else if info.pays_fee == Pays::Yes || info.class == DispatchClass::Mandatory {
+		} else if info.pays_fee == Pays::No || info.class == DispatchClass::Mandatory {
 			Some(fp_evm::PrecompileFailure::Error {
 				exit_status: ExitError::Other("Permission denied calls".into()),
 			})

--- a/runtime/darwinia/src/pallets/evm.rs
+++ b/runtime/darwinia/src/pallets/evm.rs
@@ -193,7 +193,9 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 				| RuntimeCall::MessageTransact(..)
 		) {
 			Some(fp_evm::PrecompileFailure::Error {
-				exit_status: ExitError::Other("These pallet's calls are forbidden".into()),
+				exit_status: ExitError::Other(
+					"These pallet's calls are not allowed to be called from precompile.".into(),
+				),
 			})
 		} else {
 			<() as DispatchValidateT<AccountId, RuntimeCall>>::validate_before_dispatch(

--- a/runtime/darwinia/src/pallets/evm.rs
+++ b/runtime/darwinia/src/pallets/evm.rs
@@ -18,6 +18,8 @@
 
 // darwinia
 use crate::*;
+// substrate
+use frame_support::dispatch::{DispatchClass, GetDispatchInfo, Pays};
 // frontier
 use pallet_evm::{ExitError, IsPrecompileResult, Precompile};
 use pallet_evm_precompile_dispatch::DispatchValidateT;
@@ -181,13 +183,14 @@ fn addr(a: u64) -> sp_core::H160 {
 pub struct DarwiniaDispatchValidator;
 impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 	fn validate_before_dispatch(
-		origin: &AccountId,
+		_origin: &AccountId,
 		call: &RuntimeCall,
 	) -> Option<fp_evm::PrecompileFailure> {
+		let info = call.get_dispatch_info();
+
 		if matches!(
 			call,
 			RuntimeCall::Assets(..)
-				| RuntimeCall::Vesting(..)
 				| RuntimeCall::Ethereum(..)
 				| RuntimeCall::EVM(..)
 				| RuntimeCall::MessageTransact(..)
@@ -197,10 +200,12 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 					"These pallet's calls are not allowed to be called from precompile.".into(),
 				),
 			})
+		} else if info.pays_fee != Pays::Yes || info.class == DispatchClass::Mandatory {
+			Some(fp_evm::PrecompileFailure::Error {
+				exit_status: ExitError::Other("Permission denied calls".into()),
+			})
 		} else {
-			<() as DispatchValidateT<AccountId, RuntimeCall>>::validate_before_dispatch(
-				origin, call,
-			)
+			None
 		}
 	}
 }

--- a/runtime/pangolin/src/pallets/evm.rs
+++ b/runtime/pangolin/src/pallets/evm.rs
@@ -203,7 +203,7 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 					"These pallet's calls are not allowed to be called from precompile.".into(),
 				),
 			})
-		} else if info.pays_fee == Pays::Yes || info.class == DispatchClass::Mandatory {
+		} else if info.pays_fee == Pays::No || info.class == DispatchClass::Mandatory {
 			Some(fp_evm::PrecompileFailure::Error {
 				exit_status: ExitError::Other("Permission denied calls".into()),
 			})

--- a/runtime/pangolin/src/pallets/evm.rs
+++ b/runtime/pangolin/src/pallets/evm.rs
@@ -195,7 +195,9 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 				| RuntimeCall::MessageTransact(..)
 		) {
 			Some(fp_evm::PrecompileFailure::Error {
-				exit_status: ExitError::Other("These pallet's calls are forbidden".into()),
+				exit_status: ExitError::Other(
+					"These pallet's calls are not allowed to be called from precompile.".into(),
+				),
 			})
 		} else {
 			<() as DispatchValidateT<AccountId, RuntimeCall>>::validate_before_dispatch(

--- a/runtime/pangolin/src/pallets/evm.rs
+++ b/runtime/pangolin/src/pallets/evm.rs
@@ -203,7 +203,7 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 					"These pallet's calls are not allowed to be called from precompile.".into(),
 				),
 			})
-		} else if info.pays_fee != Pays::Yes || info.class == DispatchClass::Mandatory {
+		} else if info.pays_fee == Pays::Yes || info.class == DispatchClass::Mandatory {
 			Some(fp_evm::PrecompileFailure::Error {
 				exit_status: ExitError::Other("Permission denied calls".into()),
 			})

--- a/runtime/pangolin/src/pallets/evm.rs
+++ b/runtime/pangolin/src/pallets/evm.rs
@@ -18,6 +18,8 @@
 
 // darwinia
 use crate::*;
+// substrate
+use frame_support::dispatch::{DispatchClass, GetDispatchInfo, Pays};
 // frontier
 use pallet_evm::{ExitError, IsPrecompileResult, Precompile};
 use pallet_evm_precompile_dispatch::DispatchValidateT;
@@ -184,9 +186,11 @@ fn addr(a: u64) -> sp_core::H160 {
 pub struct DarwiniaDispatchValidator;
 impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 	fn validate_before_dispatch(
-		origin: &AccountId,
+		_origin: &AccountId,
 		call: &RuntimeCall,
 	) -> Option<fp_evm::PrecompileFailure> {
+		let info = call.get_dispatch_info();
+
 		if matches!(
 			call,
 			RuntimeCall::Assets(..)
@@ -199,10 +203,12 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 					"These pallet's calls are not allowed to be called from precompile.".into(),
 				),
 			})
+		} else if info.pays_fee != Pays::Yes || info.class == DispatchClass::Mandatory {
+			Some(fp_evm::PrecompileFailure::Error {
+				exit_status: ExitError::Other("Permission denied calls".into()),
+			})
 		} else {
-			<() as DispatchValidateT<AccountId, RuntimeCall>>::validate_before_dispatch(
-				origin, call,
-			)
+			None
 		}
 	}
 }

--- a/runtime/pangoro/src/pallets/evm.rs
+++ b/runtime/pangoro/src/pallets/evm.rs
@@ -18,6 +18,8 @@
 
 // darwinia
 use crate::*;
+// substrate
+use frame_support::dispatch::{DispatchClass, GetDispatchInfo, Pays};
 // frontier
 use pallet_evm::{ExitError, IsPrecompileResult, Precompile};
 use pallet_evm_precompile_dispatch::DispatchValidateT;
@@ -182,9 +184,11 @@ fn addr(a: u64) -> sp_core::H160 {
 pub struct DarwiniaDispatchValidator;
 impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 	fn validate_before_dispatch(
-		origin: &AccountId,
+		_origin: &AccountId,
 		call: &RuntimeCall,
 	) -> Option<fp_evm::PrecompileFailure> {
+		let info = call.get_dispatch_info();
+
 		if matches!(
 			call,
 			RuntimeCall::Assets(..)
@@ -197,10 +201,12 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 					"These pallet's calls are not allowed to be called from precompile.".into(),
 				),
 			})
+		} else if info.pays_fee != Pays::Yes || info.class == DispatchClass::Mandatory {
+			Some(fp_evm::PrecompileFailure::Error {
+				exit_status: ExitError::Other("Permission denied calls".into()),
+			})
 		} else {
-			<() as DispatchValidateT<AccountId, RuntimeCall>>::validate_before_dispatch(
-				origin, call,
-			)
+			None
 		}
 	}
 }

--- a/runtime/pangoro/src/pallets/evm.rs
+++ b/runtime/pangoro/src/pallets/evm.rs
@@ -201,7 +201,7 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 					"These pallet's calls are not allowed to be called from precompile.".into(),
 				),
 			})
-		} else if info.pays_fee != Pays::Yes || info.class == DispatchClass::Mandatory {
+		} else if info.pays_fee == Pays::Yes || info.class == DispatchClass::Mandatory {
 			Some(fp_evm::PrecompileFailure::Error {
 				exit_status: ExitError::Other("Permission denied calls".into()),
 			})

--- a/runtime/pangoro/src/pallets/evm.rs
+++ b/runtime/pangoro/src/pallets/evm.rs
@@ -201,7 +201,7 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 					"These pallet's calls are not allowed to be called from precompile.".into(),
 				),
 			})
-		} else if info.pays_fee == Pays::Yes || info.class == DispatchClass::Mandatory {
+		} else if info.pays_fee == Pays::No || info.class == DispatchClass::Mandatory {
 			Some(fp_evm::PrecompileFailure::Error {
 				exit_status: ExitError::Other("Permission denied calls".into()),
 			})

--- a/runtime/pangoro/src/pallets/evm.rs
+++ b/runtime/pangoro/src/pallets/evm.rs
@@ -193,7 +193,9 @@ impl DispatchValidateT<AccountId, RuntimeCall> for DarwiniaDispatchValidator {
 				| RuntimeCall::MessageTransact(..)
 		) {
 			Some(fp_evm::PrecompileFailure::Error {
-				exit_status: ExitError::Other("These pallet's calls are forbidden".into()),
+				exit_status: ExitError::Other(
+					"These pallet's calls are not allowed to be called from precompile.".into(),
+				),
 			})
 		} else {
 			<() as DispatchValidateT<AccountId, RuntimeCall>>::validate_before_dispatch(


### PR DESCRIPTION
The current darwinia dispatch precompile filter uses the frontier filter by default, which blocks all the operational class runtime calls, including most of the governance calls, such as council vote, tc vote. This pr updates the filter rule to allow the both normal and operational calls to be dispatched via the precompile path.