### PR TITLE
Adjust `GasLimitPovSizeRatio`

### DIFF
--- a/runtime/common/src/test.rs
+++ b/runtime/common/src/test.rs
@@ -611,7 +611,7 @@ macro_rules! impl_weight_tests {
 			}
 
 			#[test]
-			fn max_allowed_eth_transaction_gas_limit() {
+			fn eth_transaction_max_allowed_gas_limit() {
 				// frontier
 				use pallet_evm::GasWeightMapping;
 

--- a/runtime/common/src/test.rs
+++ b/runtime/common/src/test.rs
@@ -609,6 +609,38 @@ macro_rules! impl_weight_tests {
 				let time_o_proof = time_fee.checked_div(proof_fee).unwrap_or_default();
 				assert!(time_o_proof <= 30, "{} should be at most 30", time_o_proof);
 			}
+
+			#[test]
+			fn max_allowed_eth_transaction_gas_limit() {
+				// frontier
+				use pallet_evm::GasWeightMapping;
+
+				let max_extrinsic_weight = <Runtime as frame_system::Config>::BlockWeights::get()
+					.get(DispatchClass::Normal)
+					.max_extrinsic
+					.expect("Failed to get max extrinsic weight");
+
+				assert!(!<Runtime as pallet_evm::Config>::GasWeightMapping::gas_to_weight(
+					12_000_000, true
+				)
+				.any_gt(max_extrinsic_weight));
+				assert!(!<Runtime as pallet_evm::Config>::GasWeightMapping::gas_to_weight(
+					14_000_000, true
+				)
+				.any_gt(max_extrinsic_weight));
+				assert!(!<Runtime as pallet_evm::Config>::GasWeightMapping::gas_to_weight(
+					16_000_000, true
+				)
+				.any_gt(max_extrinsic_weight));
+				assert!(!<Runtime as pallet_evm::Config>::GasWeightMapping::gas_to_weight(
+					18_000_000, true
+				)
+				.any_gt(max_extrinsic_weight));
+				assert!(<Runtime as pallet_evm::Config>::GasWeightMapping::gas_to_weight(
+					20_000_000, true
+				)
+				.any_gt(max_extrinsic_weight));
+			}
 		}
 	};
 }

--- a/runtime/crab/src/pallets/evm.rs
+++ b/runtime/crab/src/pallets/evm.rs
@@ -28,7 +28,7 @@ use pallet_evm_precompile_dispatch::DispatchValidateT;
 const BLOCK_GAS_LIMIT: u64 = 20_000_000;
 frame_support::parameter_types! {
 	pub BlockGasLimit: sp_core::U256 = sp_core::U256::from(BLOCK_GAS_LIMIT);
-	// Restrict the POV size of the Ethereum transactions in the same way as Gas Limit.
+	// Restrict the POV size of the Ethereum transactions in the same way as weight limit.
 	pub BlockPovSizeLimit: u64 = NORMAL_DISPATCH_RATIO * MAX_POV_SIZE as u64;
 	pub PrecompilesValue: CrabPrecompiles<Runtime> = CrabPrecompiles::<_>::new();
 	pub WeightPerGas: frame_support::weights::Weight = frame_support::weights::Weight::from_parts(

--- a/runtime/crab/src/pallets/evm.rs
+++ b/runtime/crab/src/pallets/evm.rs
@@ -19,21 +19,24 @@
 // darwinia
 use crate::*;
 // substrate
+use cumulus_primitives_core::relay_chain::MAX_POV_SIZE;
 use frame_support::dispatch::{DispatchClass, GetDispatchInfo, Pays};
 // frontier
 use pallet_evm::{ExitError, IsPrecompileResult, Precompile};
 use pallet_evm_precompile_dispatch::DispatchValidateT;
 
 const BLOCK_GAS_LIMIT: u64 = 20_000_000;
-const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
 frame_support::parameter_types! {
 	pub BlockGasLimit: sp_core::U256 = sp_core::U256::from(BLOCK_GAS_LIMIT);
+	// Restrict the POV size of the Ethereum transactions in the same way as Gas Limit.
+	pub BlockPovSizeLimit: u64 = NORMAL_DISPATCH_RATIO * MAX_POV_SIZE as u64;
 	pub PrecompilesValue: CrabPrecompiles<Runtime> = CrabPrecompiles::<_>::new();
 	pub WeightPerGas: frame_support::weights::Weight = frame_support::weights::Weight::from_parts(
 		fp_evm::weight_per_gas(BLOCK_GAS_LIMIT, NORMAL_DISPATCH_RATIO, WEIGHT_MILLISECS_PER_BLOCK),
 		0
 	);
-	pub const GasLimitPovSizeRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(MAX_POV_SIZE);
+	// TODO: FIX ME. https://github.com/rust-lang/rust/issues/88581
+	pub GasLimitPovSizeRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(BlockPovSizeLimit::get()) + 1;
 }
 
 pub struct CrabPrecompiles<R>(sp_std::marker::PhantomData<R>);

--- a/runtime/darwinia/src/pallets/evm.rs
+++ b/runtime/darwinia/src/pallets/evm.rs
@@ -28,7 +28,7 @@ use pallet_evm_precompile_dispatch::DispatchValidateT;
 const BLOCK_GAS_LIMIT: u64 = 20_000_000;
 frame_support::parameter_types! {
 	pub BlockGasLimit: sp_core::U256 = sp_core::U256::from(BLOCK_GAS_LIMIT);
-	// Restrict the POV size of the Ethereum transactions in the same way as Gas Limit.
+	// Restrict the POV size of the Ethereum transactions in the same way as weight limit.
 	pub BlockPovSizeLimit: u64 = NORMAL_DISPATCH_RATIO * MAX_POV_SIZE as u64;
 	pub PrecompilesValue: DarwiniaPrecompiles<Runtime> = DarwiniaPrecompiles::<_>::new();
 	pub WeightPerGas: frame_support::weights::Weight = frame_support::weights::Weight::from_parts(

--- a/runtime/pangolin/src/pallets/evm.rs
+++ b/runtime/pangolin/src/pallets/evm.rs
@@ -35,7 +35,6 @@ frame_support::parameter_types! {
 		fp_evm::weight_per_gas(BLOCK_GAS_LIMIT, NORMAL_DISPATCH_RATIO, WEIGHT_MILLISECS_PER_BLOCK),
 		0
 	);
-	//
 	// TODO: FIX ME. https://github.com/rust-lang/rust/issues/88581
 	pub GasLimitPovSizeRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(BlockPovSizeLimit::get()) + 1;
 }

--- a/runtime/pangolin/src/pallets/evm.rs
+++ b/runtime/pangolin/src/pallets/evm.rs
@@ -26,6 +26,7 @@ use pallet_evm_precompile_dispatch::DispatchValidateT;
 
 const BLOCK_GAS_LIMIT: u64 = 20_000_000;
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
+const ETH_MAX_POV_SIZE: u64 = MAX_POV_SIZE * 3 / 4;
 frame_support::parameter_types! {
 	pub BlockGasLimit: sp_core::U256 = sp_core::U256::from(BLOCK_GAS_LIMIT);
 	pub PrecompilesValue: PangolinPrecompiles<Runtime> = PangolinPrecompiles::<_>::new();
@@ -33,7 +34,7 @@ frame_support::parameter_types! {
 		fp_evm::weight_per_gas(BLOCK_GAS_LIMIT, NORMAL_DISPATCH_RATIO, WEIGHT_MILLISECS_PER_BLOCK),
 		0
 	);
-	pub const GasLimitPovSizeRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(MAX_POV_SIZE);
+	pub const GasLimitPovSizeRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(ETH_MAX_POV_SIZE) + 1;
 }
 
 pub struct PangolinPrecompiles<R>(sp_std::marker::PhantomData<R>);

--- a/runtime/pangolin/src/pallets/evm.rs
+++ b/runtime/pangolin/src/pallets/evm.rs
@@ -28,7 +28,7 @@ use pallet_evm_precompile_dispatch::DispatchValidateT;
 const BLOCK_GAS_LIMIT: u64 = 20_000_000;
 frame_support::parameter_types! {
 	pub BlockGasLimit: sp_core::U256 = sp_core::U256::from(BLOCK_GAS_LIMIT);
-	// Restrict the POV size of the Ethereum transactions in the same way as Gas Limit.
+	// Restrict the POV size of the Ethereum transactions in the same way as weight limit.
 	pub BlockPovSizeLimit: u64 = NORMAL_DISPATCH_RATIO * MAX_POV_SIZE as u64;
 	pub PrecompilesValue: PangolinPrecompiles<Runtime> = PangolinPrecompiles::<_>::new();
 	pub WeightPerGas: frame_support::weights::Weight = frame_support::weights::Weight::from_parts(

--- a/runtime/pangolin/src/pallets/evm.rs
+++ b/runtime/pangolin/src/pallets/evm.rs
@@ -19,22 +19,25 @@
 // darwinia
 use crate::*;
 // substrate
+use cumulus_primitives_core::relay_chain::MAX_POV_SIZE;
 use frame_support::dispatch::{DispatchClass, GetDispatchInfo, Pays};
 // frontier
 use pallet_evm::{ExitError, IsPrecompileResult, Precompile};
 use pallet_evm_precompile_dispatch::DispatchValidateT;
 
 const BLOCK_GAS_LIMIT: u64 = 20_000_000;
-const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
-const ETH_MAX_POV_SIZE: u64 = MAX_POV_SIZE * 3 / 4;
 frame_support::parameter_types! {
 	pub BlockGasLimit: sp_core::U256 = sp_core::U256::from(BLOCK_GAS_LIMIT);
+	// Restrict the POV size of the Ethereum transactions in the same way as Gas Limit.
+	pub BlockPovSizeLimit: u64 = NORMAL_DISPATCH_RATIO * MAX_POV_SIZE as u64;
 	pub PrecompilesValue: PangolinPrecompiles<Runtime> = PangolinPrecompiles::<_>::new();
 	pub WeightPerGas: frame_support::weights::Weight = frame_support::weights::Weight::from_parts(
 		fp_evm::weight_per_gas(BLOCK_GAS_LIMIT, NORMAL_DISPATCH_RATIO, WEIGHT_MILLISECS_PER_BLOCK),
 		0
 	);
-	pub const GasLimitPovSizeRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(ETH_MAX_POV_SIZE) + 1;
+	//
+	// TODO: FIX ME. https://github.com/rust-lang/rust/issues/88581
+	pub GasLimitPovSizeRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(BlockPovSizeLimit::get()) + 1;
 }
 
 pub struct PangolinPrecompiles<R>(sp_std::marker::PhantomData<R>);

--- a/runtime/pangolin/tests/tests.rs
+++ b/runtime/pangolin/tests/tests.rs
@@ -18,72 +18,8 @@
 
 pub mod mock;
 
-// darwinia_common_runtime::impl_weight_tests! {}
-// darwinia_common_runtime::impl_fee_tests! {}
-// darwinia_common_runtime::impl_evm_tests! {}
-// darwinia_common_runtime::impl_account_migration_tests! {}
-// darwinia_common_runtime::impl_messages_bridge_tests! {}
-
-mod evm {
-	// darwinia
-	use super::mock::*;
-	// frontier
-	use pallet_evm_precompile_dispatch::DispatchValidateT;
-	// substrate
-	use frame_support::{assert_err, pallet_prelude::DispatchClass};
-	use pallet_evm::GasWeightMapping;
-	use sp_core::{H160, U256};
-	use sp_runtime::{DispatchError, ModuleError};
-
-	#[test]
-	fn evm_constants_are_correctly() {
-		let w1 = <Runtime as pallet_evm::Config>::GasWeightMapping::gas_to_weight(12_000_000, true);
-		let max1 = <Runtime as frame_system::Config>::BlockWeights::get()
-			.get(DispatchClass::Normal)
-			.max_extrinsic
-			.unwrap();
-		println!("1200 => w: {:?}", w1);
-		println!("1200 => max: {:?}", max1);
-
-		let w2 = <Runtime as pallet_evm::Config>::GasWeightMapping::gas_to_weight(14_000_000, true);
-		let max2 = <Runtime as frame_system::Config>::BlockWeights::get()
-			.get(DispatchClass::Normal)
-			.max_extrinsic
-			.unwrap();
-		println!("1400 => w: {:?}", w2);
-		println!("1400 => max: {:?}", max2);
-
-		let w3 = <Runtime as pallet_evm::Config>::GasWeightMapping::gas_to_weight(15_000_000, true);
-		let max3 = <Runtime as frame_system::Config>::BlockWeights::get()
-			.get(DispatchClass::Normal)
-			.max_extrinsic
-			.unwrap();
-		println!("1500 => w: {:?}", w3);
-		println!("1500 => max: {:?}", max3);
-
-		let w4 = <Runtime as pallet_evm::Config>::GasWeightMapping::gas_to_weight(17_000_000, true);
-		let max4 = <Runtime as frame_system::Config>::BlockWeights::get()
-			.get(DispatchClass::Normal)
-			.max_extrinsic
-			.unwrap();
-		println!("1700 => w: {:?}", w4);
-		println!("1700 => max: {:?}", max4);
-
-		let w5 = <Runtime as pallet_evm::Config>::GasWeightMapping::gas_to_weight(19_000_000, true);
-		let max5 = <Runtime as frame_system::Config>::BlockWeights::get()
-			.get(DispatchClass::Normal)
-			.max_extrinsic
-			.unwrap();
-		println!("1900 => w: {:?}", w5);
-		println!("1900 => max: {:?}", max5);
-		assert!(false);
-	}
-}
-
-// => 1200w gas
-// w: Weight {   ref_time: 224886362000, proof_size: 4000000 }
-// max: Weight { ref_time: 349886362000, proof_size: 3670016 }
-
-// => 1400w gas
-// w: Weight {   ref_time: 262386362000, proof_size: 4666666 }
-// max: Weight { ref_time: 349886362000, proof_size: 3670016 }
+darwinia_common_runtime::impl_weight_tests! {}
+darwinia_common_runtime::impl_fee_tests! {}
+darwinia_common_runtime::impl_evm_tests! {}
+darwinia_common_runtime::impl_account_migration_tests! {}
+darwinia_common_runtime::impl_messages_bridge_tests! {}

--- a/runtime/pangolin/tests/tests.rs
+++ b/runtime/pangolin/tests/tests.rs
@@ -18,8 +18,72 @@
 
 pub mod mock;
 
-darwinia_common_runtime::impl_weight_tests! {}
-darwinia_common_runtime::impl_fee_tests! {}
-darwinia_common_runtime::impl_evm_tests! {}
-darwinia_common_runtime::impl_account_migration_tests! {}
-darwinia_common_runtime::impl_messages_bridge_tests! {}
+// darwinia_common_runtime::impl_weight_tests! {}
+// darwinia_common_runtime::impl_fee_tests! {}
+// darwinia_common_runtime::impl_evm_tests! {}
+// darwinia_common_runtime::impl_account_migration_tests! {}
+// darwinia_common_runtime::impl_messages_bridge_tests! {}
+
+mod evm {
+	// darwinia
+	use super::mock::*;
+	// frontier
+	use pallet_evm_precompile_dispatch::DispatchValidateT;
+	// substrate
+	use frame_support::{assert_err, pallet_prelude::DispatchClass};
+	use pallet_evm::GasWeightMapping;
+	use sp_core::{H160, U256};
+	use sp_runtime::{DispatchError, ModuleError};
+
+	#[test]
+	fn evm_constants_are_correctly() {
+		let w1 = <Runtime as pallet_evm::Config>::GasWeightMapping::gas_to_weight(12_000_000, true);
+		let max1 = <Runtime as frame_system::Config>::BlockWeights::get()
+			.get(DispatchClass::Normal)
+			.max_extrinsic
+			.unwrap();
+		println!("1200 => w: {:?}", w1);
+		println!("1200 => max: {:?}", max1);
+
+		let w2 = <Runtime as pallet_evm::Config>::GasWeightMapping::gas_to_weight(14_000_000, true);
+		let max2 = <Runtime as frame_system::Config>::BlockWeights::get()
+			.get(DispatchClass::Normal)
+			.max_extrinsic
+			.unwrap();
+		println!("1400 => w: {:?}", w2);
+		println!("1400 => max: {:?}", max2);
+
+		let w3 = <Runtime as pallet_evm::Config>::GasWeightMapping::gas_to_weight(15_000_000, true);
+		let max3 = <Runtime as frame_system::Config>::BlockWeights::get()
+			.get(DispatchClass::Normal)
+			.max_extrinsic
+			.unwrap();
+		println!("1500 => w: {:?}", w3);
+		println!("1500 => max: {:?}", max3);
+
+		let w4 = <Runtime as pallet_evm::Config>::GasWeightMapping::gas_to_weight(17_000_000, true);
+		let max4 = <Runtime as frame_system::Config>::BlockWeights::get()
+			.get(DispatchClass::Normal)
+			.max_extrinsic
+			.unwrap();
+		println!("1700 => w: {:?}", w4);
+		println!("1700 => max: {:?}", max4);
+
+		let w5 = <Runtime as pallet_evm::Config>::GasWeightMapping::gas_to_weight(19_000_000, true);
+		let max5 = <Runtime as frame_system::Config>::BlockWeights::get()
+			.get(DispatchClass::Normal)
+			.max_extrinsic
+			.unwrap();
+		println!("1900 => w: {:?}", w5);
+		println!("1900 => max: {:?}", max5);
+		assert!(false);
+	}
+}
+
+// => 1200w gas
+// w: Weight {   ref_time: 224886362000, proof_size: 4000000 }
+// max: Weight { ref_time: 349886362000, proof_size: 3670016 }
+
+// => 1400w gas
+// w: Weight {   ref_time: 262386362000, proof_size: 4666666 }
+// max: Weight { ref_time: 349886362000, proof_size: 3670016 }

--- a/runtime/pangoro/src/pallets/evm.rs
+++ b/runtime/pangoro/src/pallets/evm.rs
@@ -28,7 +28,7 @@ use pallet_evm_precompile_dispatch::DispatchValidateT;
 const BLOCK_GAS_LIMIT: u64 = 20_000_000;
 frame_support::parameter_types! {
 	pub BlockGasLimit: sp_core::U256 = sp_core::U256::from(BLOCK_GAS_LIMIT);
-	// Restrict the POV size of the Ethereum transactions in the same way as Gas Limit.
+	// Restrict the POV size of the Ethereum transactions in the same way as weight limit.
 	pub BlockPovSizeLimit: u64 = NORMAL_DISPATCH_RATIO * MAX_POV_SIZE as u64;
 	pub PrecompilesValue: PangoroPrecompiles<Runtime> = PangoroPrecompiles::<_>::new();
 	pub WeightPerGas: frame_support::weights::Weight = frame_support::weights::Weight::from_parts(

--- a/runtime/pangoro/src/pallets/evm.rs
+++ b/runtime/pangoro/src/pallets/evm.rs
@@ -19,21 +19,24 @@
 // darwinia
 use crate::*;
 // substrate
+use cumulus_primitives_core::relay_chain::MAX_POV_SIZE;
 use frame_support::dispatch::{DispatchClass, GetDispatchInfo, Pays};
 // frontier
 use pallet_evm::{ExitError, IsPrecompileResult, Precompile};
 use pallet_evm_precompile_dispatch::DispatchValidateT;
 
 const BLOCK_GAS_LIMIT: u64 = 20_000_000;
-const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
 frame_support::parameter_types! {
 	pub BlockGasLimit: sp_core::U256 = sp_core::U256::from(BLOCK_GAS_LIMIT);
+	// Restrict the POV size of the Ethereum transactions in the same way as Gas Limit.
+	pub BlockPovSizeLimit: u64 = NORMAL_DISPATCH_RATIO * MAX_POV_SIZE as u64;
 	pub PrecompilesValue: PangoroPrecompiles<Runtime> = PangoroPrecompiles::<_>::new();
 	pub WeightPerGas: frame_support::weights::Weight = frame_support::weights::Weight::from_parts(
 		fp_evm::weight_per_gas(BLOCK_GAS_LIMIT, NORMAL_DISPATCH_RATIO, WEIGHT_MILLISECS_PER_BLOCK),
 		0
 	);
-	pub const GasLimitPovSizeRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(MAX_POV_SIZE);
+	// TODO: FIX ME. https://github.com/rust-lang/rust/issues/88581
+	pub GasLimitPovSizeRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(BlockPovSizeLimit::get()) + 1;
 }
 
 pub struct PangoroPrecompiles<R>(sp_std::marker::PhantomData<R>);

--- a/tests/ethereum/test-bls.ts
+++ b/tests/ethereum/test-bls.ts
@@ -566,7 +566,7 @@ describe("Test Bls precompile", () => {
 	}).timeout(60000);
 
 	it("Return OutOfGas if insufficient gas", async () => {
-		bls.options.gas = 300_000;
+		bls.options.gas = 1000_000;  // Less than the normal used gas
 		await bls.methods
 			.fast_aggregate_verify(pub_keys_bytes, hexToBytes(message), hexToBytes(signature))
 			.call()


### PR DESCRIPTION
Adjust the ratio to fix the issue that transactions with gas limit over 1200w will be seen as exhausted resource ones.  The test I wrote can help reviewer sort it out.