### PR TITLE
Adjust governance parameters

### DIFF
--- a/runtime/crab/src/pallets/democracy.rs
+++ b/runtime/crab/src/pallets/democracy.rs
@@ -22,7 +22,7 @@ use crate::*;
 const ENACTMENT_PERIOD: u32 = 28 * DAYS;
 
 impl pallet_democracy::Config for Runtime {
-	type BlacklistOrigin = Root;
+	type BlacklistOrigin = RootOrAtLeastTwoThird<TechnicalCollective>;
 	type CancelProposalOrigin = RootOrAtLeastTwoThird<TechnicalCollective>;
 	type CancellationOrigin = RootOrAtLeastTwoThird<TechnicalCollective>;
 	type CooloffPeriod = ConstU32<{ 7 * DAYS }>;

--- a/runtime/crab/src/pallets/democracy.rs
+++ b/runtime/crab/src/pallets/democracy.rs
@@ -19,32 +19,24 @@
 // darwinia
 use crate::*;
 
-const ENACTMENT_PERIOD: u32 = 8 * DAYS;
+const ENACTMENT_PERIOD: u32 = 28 * DAYS;
 
 impl pallet_democracy::Config for Runtime {
 	type BlacklistOrigin = Root;
-	// To cancel a proposal before it has been passed, the technical committee must be unanimous or
-	// Root must agree.
-	type CancelProposalOrigin = RootOrAll<TechnicalCollective>;
-	// To cancel a proposal which has been passed, 2/3 of the council must agree to it.
-	type CancellationOrigin = RootOrAtLeastTwoThird<CouncilCollective>;
+	type CancelProposalOrigin = RootOrAtLeastTwoThird<TechnicalCollective>;
+	type CancellationOrigin = RootOrAtLeastTwoThird<TechnicalCollective>;
 	type CooloffPeriod = ConstU32<{ 7 * DAYS }>;
 	type Currency = Balances;
 	type EnactmentPeriod = ConstU32<ENACTMENT_PERIOD>;
-	/// A unanimous council can have the next scheduled referendum be a straight default-carries
-	/// (NTB) vote.
-	type ExternalDefaultOrigin = RootOrAll<CouncilCollective>;
-	/// A majority can have the next scheduled referendum be a straight majority-carries vote.
+	// There are no plans to use this yet.
+	type ExternalDefaultOrigin = Root;
 	type ExternalMajorityOrigin = RootOrAtLeastHalf<CouncilCollective>;
-	/// A straight majority of the council can decide what their next motion is.
 	type ExternalOrigin = RootOrAtLeastHalf<CouncilCollective>;
-	/// Two thirds of the technical committee can have an ExternalMajority/ExternalDefault vote
-	/// be tabled immediately and with a shorter voting/enactment period.
 	type FastTrackOrigin = RootOrAtLeastTwoThird<TechnicalCollective>;
 	type FastTrackVotingPeriod = ConstU32<{ 3 * HOURS }>;
 	type InstantAllowed = ConstBool<true>;
 	type InstantOrigin = RootOrAll<TechnicalCollective>;
-	type LaunchPeriod = ConstU32<{ 7 * DAYS }>;
+	type LaunchPeriod = ConstU32<{ 28 * DAYS }>;
 	type MaxBlacklisted = ConstU32<100>;
 	type MaxDeposits = ConstU32<100>;
 	type MaxProposals = ConstU32<100>;
@@ -56,10 +48,8 @@ impl pallet_democracy::Config for Runtime {
 	type Scheduler = Scheduler;
 	type Slash = Treasury;
 	type SubmitOrigin = frame_system::EnsureSigned<AccountId>;
-	// Any single technical committee member may veto a coming council proposal, however they can
-	// only do it once and it lasts only for the cool-off period.
 	type VetoOrigin = pallet_collective::EnsureMember<AccountId, TechnicalCollective>;
 	type VoteLockingPeriod = ConstU32<ENACTMENT_PERIOD>;
-	type VotingPeriod = ConstU32<{ 7 * DAYS }>;
+	type VotingPeriod = ConstU32<{ 28 * DAYS }>;
 	type WeightInfo = weights::pallet_democracy::WeightInfo<Self>;
 }

--- a/runtime/crab/src/pallets/elections_phragmen.rs
+++ b/runtime/crab/src/pallets/elections_phragmen.rs
@@ -41,7 +41,7 @@ impl pallet_elections_phragmen::Config for Runtime {
 	type PalletId = PhragmenElectionPalletId;
 	type RuntimeEvent = RuntimeEvent;
 	// Daily council elections.
-	type TermDuration = ConstU32<{ DAYS }>;
+	type TermDuration = ConstU32<{ 7 * DAYS }>;
 	// 1 storage item created, key size is 32 bytes, value size is 16+16.
 	type VotingBondBase = ConstU128<{ darwinia_deposit(1, 64) }>;
 	// Additional data per vote is 32 bytes (account id).

--- a/runtime/darwinia/src/pallets/democracy.rs
+++ b/runtime/darwinia/src/pallets/democracy.rs
@@ -22,7 +22,7 @@ use crate::*;
 const ENACTMENT_PERIOD: u32 = 28 * DAYS;
 
 impl pallet_democracy::Config for Runtime {
-	type BlacklistOrigin = Root;
+	type BlacklistOrigin = RootOrAtLeastTwoThird<TechnicalCollective>;
 	type CancelProposalOrigin = RootOrAtLeastTwoThird<TechnicalCollective>;
 	type CancellationOrigin = RootOrAtLeastTwoThird<TechnicalCollective>;
 	type CooloffPeriod = ConstU32<{ 7 * DAYS }>;

--- a/runtime/darwinia/src/pallets/democracy.rs
+++ b/runtime/darwinia/src/pallets/democracy.rs
@@ -23,23 +23,15 @@ const ENACTMENT_PERIOD: u32 = 28 * DAYS;
 
 impl pallet_democracy::Config for Runtime {
 	type BlacklistOrigin = Root;
-	// To cancel a proposal before it has been passed, the technical committee must be unanimous or
-	// Root must agree.
-	type CancelProposalOrigin = RootOrAll<TechnicalCollective>;
-	// To cancel a proposal which has been passed, 2/3 of the council must agree to it.
-	type CancellationOrigin = RootOrAtLeastTwoThird<CouncilCollective>;
+	type CancelProposalOrigin = RootOrAtLeastTwoThird<TechnicalCollective>;
+	type CancellationOrigin = RootOrAtLeastTwoThird<TechnicalCollective>;
 	type CooloffPeriod = ConstU32<{ 7 * DAYS }>;
 	type Currency = Balances;
 	type EnactmentPeriod = ConstU32<ENACTMENT_PERIOD>;
-	/// A unanimous council can have the next scheduled referendum be a straight default-carries
-	/// (NTB) vote.
-	type ExternalDefaultOrigin = RootOrAll<CouncilCollective>;
-	/// A majority can have the next scheduled referendum be a straight majority-carries vote.
+	// There are no plans to use this yet.
+	type ExternalDefaultOrigin = Root;
 	type ExternalMajorityOrigin = RootOrAtLeastHalf<CouncilCollective>;
-	/// A straight majority of the council can decide what their next motion is.
 	type ExternalOrigin = RootOrAtLeastHalf<CouncilCollective>;
-	/// Two thirds of the technical committee can have an ExternalMajority/ExternalDefault vote
-	/// be tabled immediately and with a shorter voting/enactment period.
 	type FastTrackOrigin = RootOrAtLeastTwoThird<TechnicalCollective>;
 	type FastTrackVotingPeriod = ConstU32<{ 3 * HOURS }>;
 	type InstantAllowed = ConstBool<true>;
@@ -56,8 +48,6 @@ impl pallet_democracy::Config for Runtime {
 	type Scheduler = Scheduler;
 	type Slash = Treasury;
 	type SubmitOrigin = frame_system::EnsureSigned<AccountId>;
-	// Any single technical committee member may veto a coming council proposal, however they can
-	// only do it once and it lasts only for the cool-off period.
 	type VetoOrigin = pallet_collective::EnsureMember<AccountId, TechnicalCollective>;
 	type VoteLockingPeriod = ConstU32<ENACTMENT_PERIOD>;
 	type VotingPeriod = ConstU32<{ 28 * DAYS }>;


### PR DESCRIPTION
Transfer specific responsibilities from the council to the technical committee.

And I propose refrigerating these pallets on Crab using the same parameters as Darwinia, with the goals of:
1. enhancing stability and reliability in governance v1.
2. transitioning to open governance later on.
3. ensuring easy maintenance of consistent parameters across different networks.