### PR TITLE
Remove hardcode instance

### DIFF
--- a/precompile/metadata/sol/asset.sol
+++ b/precompile/metadata/sol/asset.sol
@@ -18,12 +18,6 @@
 
 pragma solidity >=0.8.3;
 
-// @dev The KTON asset precompile address
-address constant KTON_ASSET_ADDRESS = 0x0000000000000000000000000000000000000402;
-
-/// @dev The KTON asset  contract instance
-ERC20Assets constant KTON_ASSET_CONTRACT = ERC20Assets(KTON_ASSET_ADDRESS);
-
 /// @title ERC20Assets
 /// notice The interface of ERC20Assets precompile
 interface ERC20Assets {


### PR DESCRIPTION
This interface will be used by assets in the Darwinia system, not just KTON. For example, the upcoming USDT. This PR removes the hardcoded staff.

@hujw77 @JayJay1024  It's better to let you you know this changes.