### PR TITLE
Fix release tar dirs

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -74,10 +74,10 @@ runs:
         mkdir -p $BUILD_DIR
 
         if [ "$ENABLE_TAR_BZ2" == "true" ]; then
-          tar cjSf ${BUILD_DIR}/darwinia${SUFFIX:+-$SUFFIX}-x86_64-linux-gnu.tar.bz2 target/release/darwinia
+          tar cjSf ${BUILD_DIR}/darwinia${SUFFIX:+-$SUFFIX}-x86_64-linux-gnu.tar.bz2 -C target/release darwinia
         fi
 
-        tar cf ${BUILD_DIR}/darwinia${SUFFIX:+-$SUFFIX}-x86_64-linux-gnu.tar.zst target/release/darwinia -I zstd
+        tar cf ${BUILD_DIR}/darwinia${SUFFIX:+-$SUFFIX}-x86_64-linux-gnu.tar.zst -C target/release darwinia -I zstd
     - name: Shrink cache
       if: ${{ inputs.enable_cache == 'true' && inputs.skip-build != 'true' }}
       shell: bash


### PR DESCRIPTION
Since  #1358, the distribution package directory structure is wrong.


```
$ curl -LO https://github.com/darwinia-network/darwinia/releases/download/pango-6511/darwinia-x86_64-linux-gnu.tar.bz2
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 65.0M  100 65.0M    0     0   325k      0  0:03:24  0:03:24 --:--:--  253k

$ tar -xvf darwinia-x86_64-linux-gnu.tar.bz2 -C ./
target/release/darwinia
```


