### PR TITLE
Use `deposit_creating`

### DIFF
--- a/pallet/staking/src/mock.rs
+++ b/pallet/staking/src/mock.rs
@@ -305,7 +305,7 @@ impl darwinia_staking::IssuingManager<Runtime> for OnDarwiniaSessionEnd {
 	}
 
 	fn reward(who: &AccountId, amount: Balance) -> sp_runtime::DispatchResult {
-		let _ = Balances::deposit_into_existing(who, amount);
+		let _ = Balances::deposit_creating(who, amount);
 
 		Ok(())
 	}

--- a/runtime/darwinia/src/migration.rs
+++ b/runtime/darwinia/src/migration.rs
@@ -41,7 +41,7 @@ impl frame_support::traits::OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
 }
 
 fn migrate() -> frame_support::weights::Weight {
-	migration::clear_storage_prefix(
+	let _ = migration::clear_storage_prefix(
 		b"BridgeKusamaGrandpa",
 		b"ImportedHeaders",
 		&[],

--- a/runtime/darwinia/src/pallets/staking.rs
+++ b/runtime/darwinia/src/pallets/staking.rs
@@ -93,7 +93,7 @@ impl darwinia_staking::IssuingManager<Runtime> for OnDarwiniaSessionEnd {
 	}
 
 	fn reward(who: &AccountId, amount: Balance) -> sp_runtime::DispatchResult {
-		let _ = Balances::deposit_into_existing(who, amount)?;
+		let _ = Balances::deposit_creating(who, amount)?;
 
 		Ok(())
 	}

--- a/runtime/darwinia/src/pallets/staking.rs
+++ b/runtime/darwinia/src/pallets/staking.rs
@@ -93,7 +93,7 @@ impl darwinia_staking::IssuingManager<Runtime> for OnDarwiniaSessionEnd {
 	}
 
 	fn reward(who: &AccountId, amount: Balance) -> sp_runtime::DispatchResult {
-		let _ = Balances::deposit_creating(who, amount)?;
+		let _ = Balances::deposit_creating(who, amount);
 
 		Ok(())
 	}


### PR DESCRIPTION
Because of the code at https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/system/src/lib.rs#L2194, allocation will fail for accounts with a zero balance.

Closes #1452.