### PR TITLE
Patch weight

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,13 @@
 version: 2
 updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "00:00"
+    labels:
+      - "D-Crate"
+      - "U-CI/CD"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "approx"
@@ -225,7 +225,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -445,7 +445,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
  "synstructure 0.13.1",
 ]
 
@@ -468,7 +468,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -558,7 +558,7 @@ dependencies = [
  "futures-lite 2.6.0",
  "parking",
  "polling 3.7.4",
- "rustix 0.38.43",
+ "rustix 0.38.44",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -608,7 +608,7 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.43",
+ "rustix 0.38.44",
  "windows-sys 0.48.0",
 ]
 
@@ -624,7 +624,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.43",
+ "rustix 0.38.44",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -638,13 +638,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.85"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -700,7 +700,7 @@ checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -772,7 +772,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "hash-db",
  "log",
@@ -799,13 +799,13 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "prettyplease 0.2.29",
+ "prettyplease 0.2.30",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -841,9 +841,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bitvec"
@@ -891,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
+checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
@@ -902,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "blake2s_simd"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94230421e395b9920d23df13ea5d77a20e1725331f90fbbf6df6040b33f756ae"
+checksum = "e90f7deecfac93095eb874a40febd69427776e24e1bd7f87f33ac62d6f0174df"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
@@ -913,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.5"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
+checksum = "675f87afced0413c9bb02843499dbbd3882a237645883f71a2b59644a6d2f753"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
@@ -957,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "bounded-collections"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d077619e9c237a5d1875166f5e8033e8f6bff0c96f8caf81e1c2d7738c431bf"
+checksum = "32ed0a820ed50891d36358e997d27741a6142e382242df40ff01c89bcdcc7a2b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.14.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1024,15 +1024,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byte-tools"
@@ -1042,9 +1042,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "byteorder"
@@ -1054,18 +1054,17 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.11+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
@@ -1105,7 +1104,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1119,9 +1118,9 @@ checksum = "fd6c0e7b807d60291f42f33f58480c0bfafe28ed08286446f45e463728cf9c1c"
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -1200,16 +1199,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1271,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1281,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1294,14 +1293,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1312,9 +1311,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "coarsetime"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4252bf230cb600c19826a575b31c8c9c84c6f11acfab6dfcad2e941b10b6f8e2"
+checksum = "91849686042de1b41cd81490edc83afbcb0abe5a9b6f2c4114f23ce8cca1bcf4"
 dependencies = [
  "libc",
  "wasix",
@@ -1349,7 +1348,7 @@ dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1370,12 +1369,11 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.1.3"
+version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
- "strum 0.26.3",
- "strum_macros 0.26.4",
+ "unicode-segmentation",
  "unicode-width 0.2.0",
 ]
 
@@ -1396,9 +1394,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -1428,9 +1426,29 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "tiny-keccak",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1503,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -1773,9 +1791,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-bigint"
@@ -1832,7 +1850,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1849,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1872,7 +1890,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.17.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1917,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1947,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1962,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1988,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.11.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2010,7 +2028,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2036,7 +2054,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2073,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2090,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.16.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2126,18 +2144,18 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2150,7 +2168,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2165,7 +2183,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.16.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2190,7 +2208,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2203,7 +2221,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2219,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2235,7 +2253,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2245,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "7.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2261,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.16.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2280,7 +2298,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2304,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2323,7 +2341,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "array-bytes 6.2.3",
  "async-trait",
@@ -2358,7 +2376,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2397,7 +2415,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -2431,7 +2449,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2449,9 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.137"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc894913dccfed0f84106062c284fa021c3ba70cb1d78797d6f5165d4492e45"
+checksum = "050906babad73f9b32a91cecc3063ff1e2235226dd2367dd839fd6fbc941c68a"
 dependencies = [
  "cc",
  "cxxbridge-cmd",
@@ -2463,47 +2481,47 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.137"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b2bfb6b3e8ce7f95d865a67419451832083d3186958290cee6c53e39dfcfe"
+checksum = "875d58f2ac56025a775b91a424515b5adf1e68205765f2c90e6dd81e269ae004"
 dependencies = [
  "cc",
  "codespan-reporting",
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.137"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d2cb64a95b4b5a381971482235c4db2e0208302a962acdbe314db03cbbe2fb"
+checksum = "19c3062da294104183e1c34ea9887941d4d8c74f6195ce9fbb430ac4b5290ede"
 dependencies = [
  "clap",
  "codespan-reporting",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.137"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f797b0206463c9c2a68ed605ab28892cca784f1ef066050f4942e3de26ad885"
+checksum = "f4b358173a166833ddef75fe468579f71727c789b8082d4cc77c38d08f656c59"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.137"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79010a2093848e65a3e0f7062d3f02fb2ef27f866416dfe436fccfa73d3bb59"
+checksum = "b9531217f3b5f7728244d2b7312bc6660f6b3e4cdbc118f4f1fbce48cb401a0f"
 dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2888,15 +2906,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
+checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b16d9d0d88a5273d830dac8b78ceb217ffc9b1d5404e5597a3542515329405b"
+checksum = "9f9724adfcf41f45bf652b3995837669d73c4d49a1b5ac1ff82905ac7d9b5558"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -2904,12 +2922,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
+checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3001,20 +3019,20 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.18"
+version = "0.99.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3034,7 +3052,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3123,7 +3141,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3147,9 +3165,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.96",
+ "syn 2.0.99",
  "termcolor",
- "toml 0.8.19",
+ "toml 0.8.20",
  "walkdir",
 ]
 
@@ -3173,15 +3191,15 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dtoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
 
 [[package]]
 name = "dyn-clonable"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9232f0e607a262ceb9bd5141a3dfb3e4db6994b31989bbfd845878cba59fd4"
+checksum = "a36efbb9bfd58e1723780aa04b61aba95ace6a05d9ffabfdb0b43672552f0805"
 dependencies = [
  "dyn-clonable-impl",
  "dyn-clone",
@@ -3189,20 +3207,20 @@ dependencies = [
 
 [[package]]
 name = "dyn-clonable-impl"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558e40ea573c374cf53507fd240b7ee2f5477df7cfebdb97323ec61c719399c5"
+checksum = "7e8671d54058979a37a26f3511fbf8d198ba1aa35ffb202c42587d918d77213a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "ecdsa"
@@ -3261,9 +3279,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 dependencies = [
  "serde",
 ]
@@ -3324,7 +3342,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3344,7 +3362,7 @@ checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3355,7 +3373,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3379,9 +3397,9 @@ checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -3581,10 +3599,10 @@ dependencies = [
  "blake2 0.10.6",
  "file-guard",
  "fs-err",
- "prettyplease 0.2.29",
+ "prettyplease 0.2.30",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3635,7 +3653,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3865,9 +3883,9 @@ dependencies = [
 
 [[package]]
 name = "finality-grandpa"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36530797b9bf31cd4ff126dcfee8170f86b00cfdcea3269d73133cc0415945c3"
+checksum = "b4f8f43dc520133541781ec03a8cab158ae8b7f7169cdf22e9050aa6cf0fbdfc"
 dependencies = [
  "either",
  "futures 0.3.31",
@@ -3947,7 +3965,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4074,7 +4092,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4098,7 +4116,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "42.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -4148,18 +4166,18 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "14.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "frame-election-provider-support"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -4175,7 +4193,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4205,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "array-bytes 6.2.3",
  "docify",
@@ -4220,7 +4238,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "37.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
@@ -4260,8 +4278,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "30.0.4"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+version = "30.0.5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4270,39 +4288,39 @@ dependencies = [
  "frame-support-procedural-tools",
  "itertools 0.11.0",
  "macro_magic",
- "proc-macro-warning 1.0.2",
+ "proc-macro-warning 1.84.1",
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "frame-system"
 version = "37.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4322,7 +4340,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4336,7 +4354,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4346,7 +4364,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4379,7 +4397,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f9df8a11882c4e3335eb2d18a0137c505d9ca927470b0cac9c6f0ae07d28f7"
 dependencies = [
- "rustix 0.38.43",
+ "rustix 0.38.44",
  "windows-sys 0.48.0",
 ]
 
@@ -4501,7 +4519,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -4599,8 +4617,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4708,9 +4738,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4965,9 +4995,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -5007,14 +5037,14 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.7",
+ "h2 0.4.8",
  "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
@@ -5050,12 +5080,12 @@ checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
  "http 1.2.0",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.21",
+ "rustls 0.23.23",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.2",
  "tower-service",
 ]
 
@@ -5067,7 +5097,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -5086,7 +5116,7 @@ dependencies = [
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "pin-project-lite",
  "socket2 0.5.8",
  "tokio",
@@ -5232,7 +5262,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5364,7 +5394,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5415,9 +5445,9 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
 name = "indicatif"
-version = "0.17.9"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
  "console",
  "number_prefix",
@@ -5428,9 +5458,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array 0.14.7",
 ]
@@ -5499,13 +5529,13 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5552,9 +5582,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
@@ -5621,13 +5651,13 @@ dependencies = [
  "http 1.2.0",
  "jsonrpsee-core",
  "pin-project",
- "rustls 0.23.21",
+ "rustls 0.23.23",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto 0.8.1",
  "thiserror 1.0.69",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.2",
  "tokio-util",
  "tracing",
  "url",
@@ -5671,7 +5701,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5685,7 +5715,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -5818,9 +5848,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libloading"
@@ -5848,7 +5878,7 @@ dependencies = [
  "either",
  "futures 0.3.31",
  "futures-timer",
- "getrandom",
+ "getrandom 0.2.15",
  "instant",
  "libp2p-allow-block-list",
  "libp2p-connection-limits",
@@ -6169,7 +6199,7 @@ dependencies = [
  "proc-macro-warning 0.4.2",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -6278,9 +6308,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall 0.5.10",
 ]
 
 [[package]]
@@ -6370,9 +6400,9 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
+checksum = "4a6f6da007f968f9def0d65a05b187e2960183de70c160204ecfccf0ee330212"
 dependencies = [
  "cc",
 ]
@@ -6433,9 +6463,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litep2p"
@@ -6504,9 +6534,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "lru"
@@ -6569,7 +6599,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -6583,7 +6613,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -6594,7 +6624,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -6605,7 +6635,7 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -6657,7 +6687,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.38.43",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -6733,9 +6763,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -6747,7 +6777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -6779,7 +6809,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "futures 0.3.31",
  "log",
@@ -6798,7 +6828,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -6861,7 +6891,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -7206,9 +7236,9 @@ checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -7260,17 +7290,16 @@ dependencies = [
 
 [[package]]
 name = "netlink-proto"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b33524dc0968bfad349684447bfce6db937a9ac3332a1fe60c0c5a5ce63f21"
+checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
 dependencies = [
  "bytes",
  "futures 0.3.31",
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 1.0.69",
- "tokio",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7315,7 +7344,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -7521,7 +7550,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -7580,9 +7609,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "opaque-debug"
@@ -7598,11 +7627,11 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -7619,29 +7648,29 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.1+3.4.0"
+version = "300.4.2+3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
@@ -7782,7 +7811,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-asset-conversion"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7819,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7833,7 +7862,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7849,7 +7878,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7865,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7880,7 +7909,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7893,7 +7922,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7916,7 +7945,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "aquamarine",
  "docify",
@@ -7936,8 +7965,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+version = "38.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7952,7 +7981,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7971,7 +8000,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
@@ -7995,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "36.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8012,7 +8041,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8030,7 +8059,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8048,7 +8077,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8064,7 +8093,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8080,7 +8109,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8093,7 +8122,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8110,7 +8139,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8132,7 +8161,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8145,7 +8174,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8278,7 +8307,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8296,7 +8325,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8318,7 +8347,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8334,7 +8363,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8353,7 +8382,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8369,7 +8398,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8385,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "40.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8404,7 +8433,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8421,7 +8450,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8436,7 +8465,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8451,7 +8480,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8469,7 +8498,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8489,7 +8518,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -8499,7 +8528,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8515,7 +8544,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8538,7 +8567,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8555,7 +8584,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8571,7 +8600,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8585,7 +8614,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "37.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8603,7 +8632,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8617,7 +8646,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8635,7 +8664,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8649,7 +8678,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8666,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8687,7 +8716,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8703,7 +8732,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8720,7 +8749,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8742,18 +8771,18 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -8762,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8772,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8788,7 +8817,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8803,7 +8832,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "36.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8822,7 +8851,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8840,7 +8869,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "37.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8855,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -8871,7 +8900,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -8883,7 +8912,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "36.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8901,7 +8930,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8918,7 +8947,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "37.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8933,7 +8962,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8947,7 +8976,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8961,7 +8990,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "16.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -8985,7 +9014,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9057,29 +9086,31 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.12"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
+checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
  "byte-slice-cast",
  "bytes",
+ "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
+ "rustversion",
  "serde",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.12"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
+checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -9137,7 +9168,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall 0.5.10",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -9203,7 +9234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
@@ -9227,7 +9258,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -9253,22 +9284,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.8"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.8"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -9306,14 +9337,14 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polkadot-approval-distribution"
 version = "17.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bitvec",
  "futures 0.3.31",
@@ -9333,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "always-assert",
  "futures 0.3.31",
@@ -9349,9 +9380,9 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "fatality",
  "futures 0.3.31",
  "parity-scale-codec",
@@ -9373,7 +9404,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "fatality",
@@ -9406,7 +9437,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "cfg-if",
  "clap",
@@ -9434,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9456,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9467,9 +9498,9 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "fatality",
  "futures 0.3.31",
  "futures-timer",
@@ -9492,7 +9523,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -9506,7 +9537,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -9528,7 +9559,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -9551,7 +9582,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "futures 0.3.31",
  "parity-scale-codec",
@@ -9569,10 +9600,10 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "17.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bitvec",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "futures 0.3.31",
  "futures-timer",
  "itertools 0.11.0",
@@ -9602,7 +9633,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bitvec",
  "futures 0.3.31",
@@ -9624,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9644,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-subsystem",
@@ -9659,7 +9690,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "17.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -9682,7 +9713,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-metrics",
@@ -9696,7 +9727,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -9713,7 +9744,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -9732,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -9749,7 +9780,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "16.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -9763,7 +9794,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9781,7 +9812,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.3",
@@ -9810,7 +9841,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-primitives",
@@ -9826,7 +9857,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "cpu-time",
  "futures 0.3.31",
@@ -9852,7 +9883,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-metrics",
@@ -9867,7 +9898,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "lazy_static",
  "log",
@@ -9886,7 +9917,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bs58 0.5.1",
  "futures 0.3.31",
@@ -9905,12 +9936,12 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "17.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
  "bitvec",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "fatality",
  "futures 0.3.31",
  "hex",
@@ -9931,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -9954,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -9964,11 +9995,11 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "17.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "bitvec",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "fatality",
  "futures 0.3.31",
  "orchestra",
@@ -9994,10 +10025,10 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "17.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "fatality",
  "futures 0.3.31",
  "futures-channel",
@@ -10030,7 +10061,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -10052,10 +10083,10 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bounded-collections",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "scale-info",
@@ -10068,7 +10099,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -10094,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -10129,7 +10160,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "16.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -10179,7 +10210,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bs58 0.5.1",
  "frame-benchmarking",
@@ -10191,11 +10222,11 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "16.0.3"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -10238,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "18.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -10356,7 +10387,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
@@ -10379,7 +10410,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -10436,7 +10467,7 @@ dependencies = [
  "polkavm-common",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -10446,7 +10477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -10496,7 +10527,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.43",
+ "rustix 0.38.44",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -10526,9 +10557,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "powerfmt"
@@ -10550,7 +10581,7 @@ name = "precompile-utils"
 version = "0.1.0"
 source = "git+https://github.com/polkadot-evm/frontier?branch=stable2407#2e219e17a526125da003e64ef22ec037917083fa"
 dependencies = [
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "environmental",
  "evm",
  "fp-evm",
@@ -10581,7 +10612,7 @@ source = "git+https://github.com/polkadot-evm/frontier?branch=stable2407#2e219e1
 dependencies = [
  "case",
  "num_enum 0.7.3",
- "prettyplease 0.2.29",
+ "prettyplease 0.2.30",
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
@@ -10650,12 +10681,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+checksum = "f1ccf34da56fc294e7d4ccf69a85992b7dfb826b7cf57bac6a70bba3494cc08a"
 dependencies = [
  "proc-macro2",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -10680,7 +10711,7 @@ checksum = "a172e6cc603231f2cf004232eabcecccc0da53ba576ab286ef7baa0cfc7927ad"
 dependencies = [
  "coarsetime",
  "crossbeam-queue",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "futures 0.3.31",
  "futures-timer",
  "nanorand",
@@ -10739,25 +10770,25 @@ checksum = "3d1eaa7fa0aa1929ffdf7eeb6eac234dde6268914a14ad44d23521ab6a9b258e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "proc-macro-warning"
-version = "1.0.2"
+version = "1.84.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
+checksum = "75eea531cfcd120e0851a3f8aed42c4841f78c889eefafd96339c72677ae42c3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -10796,7 +10827,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -10854,11 +10885,11 @@ dependencies = [
  "multimap 0.10.0",
  "once_cell",
  "petgraph",
- "prettyplease 0.2.29",
+ "prettyplease 0.2.30",
  "prost 0.12.6",
  "prost-types 0.12.6",
  "regex",
- "syn 2.0.96",
+ "syn 2.0.99",
  "tempfile",
 ]
 
@@ -10885,7 +10916,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -10908,9 +10939,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200b9ff220857e53e184257720a14553b2f4aa02577d2ed9842d45d4b9654810"
+checksum = "f58e5423e24c18cc840e1c98370b3993c6649cd1678b4d24318bcf0a083cbe88"
 dependencies = [
  "cc",
 ]
@@ -10925,7 +10956,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -11057,9 +11088,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -11097,7 +11128,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -11121,11 +11152,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.3.0"
+version = "11.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6928fa44c097620b706542d428957635951bade7143269085389d42c8a4927e"
+checksum = "529468c1335c1c03919960dfefdb1b3648858c20d7ec2d0663e728e4a717efbc"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -11177,11 +11208,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -11190,7 +11221,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -11201,7 +11232,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87413ebb313323d431e85d0afc5a68222aaed972843537cbfe5f061cf1b4bcab"
 dependencies = [
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "fs-err",
  "static_init",
  "thiserror 1.0.69",
@@ -11209,22 +11240,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -11307,11 +11338,11 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.7",
+ "h2 0.4.8",
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-rustls 0.27.5",
  "hyper-tls",
  "hyper-util",
@@ -11345,9 +11376,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ccd3b55e711f91a9885a2fa6fbbb2e39db1776420b062efc058c6410f7e5e3"
+checksum = "64e8975513bd9a7a43aad01030e79b3498e05db14e9d945df6483e8cf9b8c4c4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11367,9 +11398,9 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures 0.3.31",
- "getrandom",
+ "getrandom 0.2.15",
  "http 1.2.0",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "parking_lot 0.11.2",
  "reqwest",
  "reqwest-middleware",
@@ -11382,13 +11413,13 @@ dependencies = [
 
 [[package]]
 name = "reqwest-tracing"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e6153390585f6961341b50e5a1931d6be6dee4292283635903c26ef9d980d2"
+checksum = "d9c88a8d9cfe3319b5adc10f3ffc3db75c7346837a1f857f8269f6361f3b2744"
 dependencies = [
  "anyhow",
  "async-trait",
- "getrandom",
+ "getrandom 0.2.15",
  "http 1.2.0",
  "matchit",
  "opentelemetry 0.22.0",
@@ -11444,15 +11475,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
- "spin 0.9.8",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
@@ -11501,7 +11531,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -11601,7 +11631,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -11683,7 +11713,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.25",
+ "semver 1.0.26",
 ]
 
 [[package]]
@@ -11725,11 +11755,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.43"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -11754,20 +11784,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring 0.17.11",
  "rustls-webpki 0.101.7",
  "sct",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "log",
  "once_cell",
- "ring 0.17.8",
+ "ring 0.17.11",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle 2.6.1",
@@ -11819,9 +11849,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-platform-verifier"
@@ -11834,13 +11864,13 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.21",
+ "rustls 0.23.23",
  "rustls-native-certs 0.7.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.8",
  "security-framework",
  "security-framework-sys",
- "webpki-roots 0.26.7",
+ "webpki-roots 0.26.8",
  "winapi",
 ]
 
@@ -11856,7 +11886,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.11",
  "untrusted 0.9.0",
 ]
 
@@ -11866,16 +11896,16 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.11",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ruzstd"
@@ -11901,9 +11931,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "safe_arch"
@@ -11926,7 +11956,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "log",
  "sp-core",
@@ -11937,7 +11967,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -11967,7 +11997,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -11989,7 +12019,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.42.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -12004,7 +12034,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "array-bytes 6.2.3",
  "docify",
@@ -12031,18 +12061,18 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "sc-cli"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "array-bytes 6.2.3",
  "chrono",
@@ -12083,7 +12113,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "fnv",
  "futures 0.3.31",
@@ -12110,7 +12140,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -12136,7 +12166,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -12160,7 +12190,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -12189,7 +12219,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -12225,7 +12255,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "futures 0.3.31",
  "jsonrpsee",
@@ -12247,7 +12277,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -12283,7 +12313,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "futures 0.3.31",
  "jsonrpsee",
@@ -12303,7 +12333,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -12316,7 +12346,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.29.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "ahash",
  "array-bytes 6.2.3",
@@ -12360,7 +12390,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "finality-grandpa",
  "futures 0.3.31",
@@ -12380,7 +12410,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -12403,7 +12433,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -12426,7 +12456,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -12439,7 +12469,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "log",
  "polkavm",
@@ -12450,7 +12480,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -12468,7 +12498,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "ansi_term",
  "futures 0.3.31",
@@ -12485,7 +12515,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "33.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.3",
@@ -12499,7 +12529,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.14.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
@@ -12527,8 +12557,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.44.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+version = "0.44.2"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -12579,7 +12609,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -12597,7 +12627,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "ahash",
  "futures 0.3.31",
@@ -12616,7 +12646,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -12637,7 +12667,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -12674,7 +12704,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "array-bytes 6.2.3",
  "futures 0.3.31",
@@ -12693,7 +12723,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.12.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
@@ -12710,7 +12740,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "array-bytes 6.2.3",
  "bytes",
@@ -12744,7 +12774,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -12753,7 +12783,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "futures 0.3.31",
  "jsonrpsee",
@@ -12785,7 +12815,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -12805,14 +12835,14 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "16.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "forwarded-header-value",
  "futures 0.3.31",
  "governor",
  "http 1.2.0",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "ip_network",
  "jsonrpsee",
  "log",
@@ -12827,7 +12857,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "array-bytes 6.2.3",
  "futures 0.3.31",
@@ -12859,7 +12889,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "directories",
@@ -12923,7 +12953,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.36.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -12934,7 +12964,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "clap",
  "fs4",
@@ -12947,7 +12977,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -12966,9 +12996,9 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "futures 0.3.31",
  "libc",
  "log",
@@ -12987,7 +13017,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "chrono",
  "futures 0.3.31",
@@ -13007,7 +13037,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -13037,18 +13067,18 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -13075,7 +13105,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -13091,7 +13121,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-channel 1.9.0",
  "futures 0.3.31",
@@ -13126,7 +13156,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -13192,9 +13222,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scratch"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
+checksum = "9f6280af86e5f559536da57a45ebc84948833b3bee313a7dd25232e09c878a52"
 
 [[package]]
 name = "sct"
@@ -13202,7 +13232,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.11",
  "untrusted 0.9.0",
 ]
 
@@ -13278,7 +13308,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -13307,9 +13337,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
@@ -13328,38 +13358,38 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
+checksum = "364fec0df39c49a083c9a8a18a23a6bcfd9af130fe9fe321d18520a0d113e09e"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -13536,9 +13566,9 @@ dependencies = [
 
 [[package]]
 name = "similar-asserts"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f08357795f0d604ea7d7130f22c74b03838c959bdb14adde3142aab4d18a293"
+checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
 dependencies = [
  "console",
  "similar",
@@ -13550,7 +13580,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cae9a3fcdadafb6d97f4c0e007e4247b114ee0f119f650c3cbf3a8b3a1479694"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -13583,7 +13613,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -13602,9 +13632,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "smol"
@@ -13638,7 +13668,7 @@ dependencies = [
  "bs58 0.5.1",
  "chacha20",
  "crossbeam-queue",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "ed25519-zebra",
  "either",
  "event-listener 2.5.3",
@@ -13687,7 +13717,7 @@ dependencies = [
  "async-lock 2.8.0",
  "base64 0.21.7",
  "blake2-rfc",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "either",
  "event-listener 2.5.3",
  "fnv",
@@ -13730,7 +13760,7 @@ dependencies = [
  "chacha20poly1305",
  "curve25519-dalek",
  "rand_core",
- "ring 0.17.8",
+ "ring 0.17.11",
  "rustc_version",
  "sha2 0.10.8",
  "subtle 2.6.1",
@@ -13790,7 +13820,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "docify",
  "hash-db",
@@ -13812,7 +13842,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -13820,13 +13850,13 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13838,7 +13868,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -13852,7 +13882,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13864,7 +13894,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -13874,7 +13904,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "37.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "futures 0.3.31",
  "parity-scale-codec",
@@ -13893,7 +13923,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -13908,7 +13938,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13924,7 +13954,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13942,7 +13972,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -13962,7 +13992,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -13979,7 +14009,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13990,7 +14020,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "array-bytes 6.2.3",
  "bitflags 1.3.2",
@@ -14036,7 +14066,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -14049,17 +14079,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -14068,17 +14098,17 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -14088,7 +14118,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14100,7 +14130,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -14113,7 +14143,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bytes",
  "docify",
@@ -14139,7 +14169,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -14149,7 +14179,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -14160,7 +14190,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -14169,7 +14199,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -14179,7 +14209,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14190,7 +14220,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -14207,7 +14237,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14220,7 +14250,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -14230,7 +14260,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -14240,7 +14270,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "32.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -14250,7 +14280,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "39.0.3"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "docify",
  "either",
@@ -14276,7 +14306,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -14295,20 +14325,20 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "Inflector",
  "expander",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "sp-session"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14322,7 +14352,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -14335,7 +14365,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "hash-db",
  "log",
@@ -14355,7 +14385,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -14379,12 +14409,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -14396,7 +14426,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14408,7 +14438,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -14419,7 +14449,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -14428,7 +14458,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14442,7 +14472,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "ahash",
  "hash-db",
@@ -14465,7 +14495,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -14482,18 +14512,18 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -14505,7 +14535,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -14694,7 +14724,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -14707,7 +14737,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "14.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections",
@@ -14725,7 +14755,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "16.0.3"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -14746,7 +14776,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -14861,13 +14891,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -14892,7 +14922,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 
 [[package]]
 name = "substrate-fixed"
@@ -14908,7 +14938,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -14928,10 +14958,10 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
  "prometheus",
@@ -14942,7 +14972,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -14969,7 +14999,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -14980,7 +15010,7 @@ dependencies = [
  "sp-maybe-compressed-blob",
  "strum 0.26.3",
  "tempfile",
- "toml 0.8.19",
+ "toml 0.8.20",
  "walkdir",
  "wasm-opt",
 ]
@@ -15016,9 +15046,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15054,7 +15084,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -15063,7 +15093,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -15101,15 +15131,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand 2.3.0",
- "getrandom",
+ "getrandom 0.3.1",
  "once_cell",
- "rustix 0.38.43",
+ "rustix 0.38.44",
  "windows-sys 0.59.0",
 ]
 
@@ -15128,7 +15158,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
 dependencies = [
- "rustix 0.38.43",
+ "rustix 0.38.44",
  "windows-sys 0.59.0",
 ]
 
@@ -15149,11 +15179,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -15173,7 +15203,7 @@ checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -15184,18 +15214,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -15309,9 +15339,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -15348,7 +15378,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -15373,11 +15403,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.21",
+ "rustls 0.23.23",
  "tokio",
 ]
 
@@ -15445,9 +15475,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -15466,9 +15496,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap 2.7.1",
  "serde",
@@ -15513,7 +15543,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "bytes",
  "http 1.2.0",
  "http-body 1.0.1",
@@ -15555,7 +15585,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -15581,7 +15611,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -15592,13 +15622,13 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "expander",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -15681,7 +15711,7 @@ dependencies = [
  "reqwest-retry",
  "reqwest-tracing",
  "task-local-extensions",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-opentelemetry 0.28.0",
@@ -15827,9 +15857,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ucd-trie"
@@ -15857,9 +15887,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-normalization"
@@ -16065,12 +16095,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasix"
 version = "0.12.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fbb4ef9bbca0c1170e0b00dd28abc9e3b68669821600cad1caaed606583c6d"
 dependencies = [
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -16095,7 +16134,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
  "wasm-bindgen-shared",
 ]
 
@@ -16130,7 +16169,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -16492,7 +16531,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.11",
  "untrusted 0.9.0",
 ]
 
@@ -16504,9 +16543,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -16514,7 +16553,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -16620,7 +16659,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -16642,7 +16681,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.43",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -16720,6 +16759,12 @@ dependencies = [
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-registry"
@@ -16991,9 +17036,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
 dependencies = [
  "memchr",
 ]
@@ -17006,6 +17051,15 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -17106,18 +17160,18 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "10.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.3.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#39e71bd58f282508db334a424ca6c2997d94acf5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#0f858bae0a27ffda3351574012fafff1beb09384"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -17187,7 +17241,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
  "synstructure 0.13.1",
 ]
 
@@ -17209,27 +17263,27 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
  "synstructure 0.13.1",
 ]
 
@@ -17250,7 +17304,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -17272,7 +17326,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -17315,9 +17369,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.14+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "8fb060d4926e4ac3a3ad15d864e99ceb5f343c6b34f5bd6d81ae6ed417311be5"
 dependencies = [
  "cc",
  "pkg-config",

--- a/runtime/crab/src/weights/pallet_scheduler.rs
+++ b/runtime/crab/src/weights/pallet_scheduler.rs
@@ -100,14 +100,14 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for WeightInfo<T> {
 	fn service_task_fetched(s: u32, ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `179 + s * (1 ±0)`
-		//  Estimated: `4197809`
-		// Minimum execution time: 13_000_000 picoseconds.
-		Weight::from_parts(8_555_200, 0)
-			.saturating_add(Weight::from_parts(0, 4197809))
-			// Standard Error: 8
-			.saturating_add(Weight::from_parts(478, 0).saturating_mul(s.into()))
-			.saturating_add(T::DbWeight::get().reads(3))
-			.saturating_add(T::DbWeight::get().writes(2))
+		//  Estimated: `3644 + s * (1 ±0)`
+		// Minimum execution time: 19_743_000 picoseconds.
+		Weight::from_parts(19_962_000, 3644)
+			// Standard Error: 6
+			.saturating_add(Weight::from_parts(1_257, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+			.saturating_add(Weight::from_parts(0, 1).saturating_mul(s.into()))
 	}
 	/// Storage: `Scheduler::Lookup` (r:0 w:1)
 	/// Proof: `Scheduler::Lookup` (`max_values`: None, `max_size`: Some(48), added: 2523, mode: `MaxEncodedLen`)

--- a/runtime/darwinia/src/weights/pallet_scheduler.rs
+++ b/runtime/darwinia/src/weights/pallet_scheduler.rs
@@ -100,14 +100,14 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for WeightInfo<T> {
 	fn service_task_fetched(s: u32, ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `179 + s * (1 ±0)`
-		//  Estimated: `4197809`
-		// Minimum execution time: 13_000_000 picoseconds.
-		Weight::from_parts(13_000_000, 0)
-			.saturating_add(Weight::from_parts(0, 4197809))
-			// Standard Error: 5
-			.saturating_add(Weight::from_parts(541, 0).saturating_mul(s.into()))
-			.saturating_add(T::DbWeight::get().reads(3))
-			.saturating_add(T::DbWeight::get().writes(2))
+		//  Estimated: `3644 + s * (1 ±0)`
+		// Minimum execution time: 19_743_000 picoseconds.
+		Weight::from_parts(19_962_000, 3644)
+			// Standard Error: 6
+			.saturating_add(Weight::from_parts(1_257, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+			.saturating_add(Weight::from_parts(0, 1).saturating_mul(s.into()))
 	}
 	/// Storage: `Scheduler::Lookup` (r:0 w:1)
 	/// Proof: `Scheduler::Lookup` (`max_values`: None, `max_size`: Some(48), added: 2523, mode: `MaxEncodedLen`)


### PR DESCRIPTION
After some digging and research, I discovered that this is a bug in the upstream version. Polkadot Collectives is also experiencing this issue. I reported the bug to Parity, and it has been confirmed. However, there is no official fix available at the moment. In the meantime, you can simply roll back the weight and adopt Moonbeam's weight.


- Temporarily fix scheduler weight
  - https://github.com/moonbeam-foundation/moonbeam/blob/650a3cd4b9852605e74d606ced330025d745b74d/runtime/moonbase/src/weights/pallet_scheduler.rs#L90-L101
- Include a small patch from upstream https://github.com/paritytech/polkadot-sdk/pull/7525
