### PR TITLE
Fix Try Runtime comment trigger

### DIFF
--- a/.github/workflows/try-runtime-gate.yml
+++ b/.github/workflows/try-runtime-gate.yml
@@ -4,16 +4,21 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   gate:
     if: >
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '/bot try-runtime')
+    outputs:
+      disable_idempotency_checks: ${{ steps.request.outputs.disable_idempotency_checks }}
+      disable_spec_version_check: ${{ steps.request.outputs.disable_spec_version_check }}
+      pr_number: ${{ steps.request.outputs.pr_number }}
+      target_sha: ${{ steps.request.outputs.target_sha }}
+    permissions:
+      issues: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: Verify requester is trusted
@@ -38,42 +43,64 @@ jobs:
             });
             core.setFailed('Unauthorized')
 
-      - name: Build label list from comment flags
-        id: labels
-        env:
-          BODY: ${{ github.event.comment.body }}
-        run: |
-          labels=("try-runtime")
-          if echo "$BODY" | grep -q -- '--disable-spec-version-check'; then
-            labels+=("try-runtime:skip-spec-check")
-          fi
-          if echo "$BODY" | grep -q -- '--disable-idempotency-checks'; then
-            labels+=("try-runtime:skip-idempotency")
-          fi
-          printf '%s\n' "${labels[@]}" | jq -R . | jq -s . > labels.json
-          echo "labels=$(cat labels.json)" >> "$GITHUB_OUTPUT"
-
-      - name: Add labels to PR
+      - name: Resolve request
+        id: request
         uses: actions/github-script@v8
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         with:
           script: |
-            const ls = JSON.parse(process.env.LABELS);
-            await github.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
-              labels: ls
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.issue.number;
+            const { data: pull } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number
             });
-        env:
-          LABELS: ${{ steps.labels.outputs.labels }}
+
+            if (pull.state === 'closed' && !pull.merged) {
+              core.setFailed('Try Runtime cannot run for a closed, unmerged pull request.');
+              return;
+            }
+            if (pull.merged && !pull.merge_commit_sha) {
+              core.setFailed('The merged pull request has no merge commit SHA.');
+              return;
+            }
+
+            const targetSha = pull.merged ? pull.merge_commit_sha : pull.head.sha;
+            const comment = process.env.COMMENT_BODY || '';
+            core.setOutput('pr_number', String(pull_number));
+            core.setOutput('target_sha', targetSha);
+            core.setOutput(
+              'disable_spec_version_check',
+              String(comment.includes('--disable-spec-version-check'))
+            );
+            core.setOutput(
+              'disable_idempotency_checks',
+              String(comment.includes('--disable-idempotency-checks'))
+            );
 
       - name: Acknowledge
         uses: actions/github-script@v8
+        env:
+          TARGET_SHA: ${{ steps.request.outputs.target_sha }}
         with:
           script: |
-            await github.issues.createComment({
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body: `⏳ Queued **Try Runtime**. A PR job will execute and post results here.`
+              body: `⏳ Queued **Try Runtime** for \`${process.env.TARGET_SHA}\`. The workflow will post results here.`
             });
+
+  try-runtime:
+    needs: gate
+    permissions:
+      contents: read
+      issues: write
+    uses: ./.github/workflows/try-runtime-pr.yml
+    with:
+      disable_idempotency_checks: ${{ needs.gate.outputs.disable_idempotency_checks == 'true' }}
+      disable_spec_version_check: ${{ needs.gate.outputs.disable_spec_version_check == 'true' }}
+      pr_number: ${{ needs.gate.outputs.pr_number }}
+      target_sha: ${{ needs.gate.outputs.target_sha }}

--- a/.github/workflows/try-runtime-pr.yml
+++ b/.github/workflows/try-runtime-pr.yml
@@ -3,13 +3,31 @@ name: Try Runtime (PR)
 on:
   pull_request:
     types: [labeled, synchronize, reopened]
+  workflow_call:
+    inputs:
+      pr_number:
+        description: Pull request number for result comments
+        required: true
+        type: string
+      target_sha:
+        description: Commit SHA to test
+        required: true
+        type: string
+      disable_spec_version_check:
+        description: Disable the spec-version check
+        default: false
+        required: false
+        type: boolean
+      disable_idempotency_checks:
+        description: Disable idempotency checks
+        default: false
+        required: false
+        type: boolean
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 concurrency:
-  group: pr-${{ github.event.pull_request.number }}-try-runtime
+  group: pr-${{ inputs.pr_number || github.event.pull_request.number }}-try-runtime
   cancel-in-progress: true
 
 env:
@@ -19,32 +37,52 @@ env:
 
 jobs:
   try-runtime:
-    if: contains(github.event.pull_request.labels.*.name, 'try-runtime')
+    if: >
+      inputs.pr_number != '' ||
+      contains(github.event.pull_request.labels.*.name, 'try-runtime')
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         runtime:
           - name: darwinia-runtime
             uri: wss://rpc.darwinia.network
           - name: crab-runtime
             uri: ws://g1.crab2.darwinia.network:9944
+    env:
+      PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+      TARGET_SHA: ${{ inputs.target_sha || github.event.pull_request.head.sha }}
 
     steps:
-      - name: Checkout PR code (unprivileged)
+      - name: Checkout requested code (unprivileged)
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ env.TARGET_SHA }}
           persist-credentials: false
 
-      - name: Resolve flags from labels
+      - name: Resolve flags
         id: flags
+        env:
+          CALL_DISABLE_IDEMP: ${{ inputs.disable_idempotency_checks }}
+          CALL_DISABLE_SPEC: ${{ inputs.disable_spec_version_check }}
+          CALL_PR_NUMBER: ${{ inputs.pr_number }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
-          labels='${{ toJson(github.event.pull_request.labels.*.name) }}'
-          echo "$labels" > labels.txt
-          spec=false
-          idemp=false
-          grep -q 'try-runtime:skip-spec-check' labels.txt && spec=true
-          grep -q 'try-runtime:skip-idempotency' labels.txt && idemp=true
+          if [[ -n "$CALL_PR_NUMBER" ]]; then
+            spec="$CALL_DISABLE_SPEC"
+            idemp="$CALL_DISABLE_IDEMP"
+          else
+            spec=false
+            idemp=false
+            if grep -q 'try-runtime:skip-spec-check' <<< "$PR_LABELS"; then
+              spec=true
+            fi
+            if grep -q 'try-runtime:skip-idempotency' <<< "$PR_LABELS"; then
+              idemp=true
+            fi
+          fi
           echo "disable_spec=$spec" >> "$GITHUB_OUTPUT"
           echo "disable_idemp=$idemp" >> "$GITHUB_OUTPUT"
 
@@ -66,8 +104,8 @@ jobs:
           mkdir -p out
           {
             echo "### Try Runtime Result"
-            echo "- PR: #${{ github.event.pull_request.number }}"
-            echo "- Commit: \`${{ github.event.pull_request.head.sha }}\`"
+            echo "- PR: #$PR_NUMBER"
+            echo "- Commit: \`$TARGET_SHA\`"
             echo "- Runtime: \`${{ matrix.runtime.name }}\`"
             echo "- URI: \`${{ matrix.runtime.uri }}\`"
             echo "- Disable spec-version check: \`${{ steps.flags.outputs.disable_spec }}\`"
@@ -79,33 +117,54 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: try-runtime-${{ github.event.pull_request.number }}
+          name: try-runtime-${{ env.PR_NUMBER }}-${{ matrix.runtime.name }}
           path: out/
 
-      - name: Post comment to PR
-        if: always()
+  report:
+    if: >
+      always() &&
+      (inputs.pr_number != '' ||
+      contains(github.event.pull_request.labels.*.name, 'try-runtime'))
+    needs: try-runtime
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    env:
+      DISABLE_IDEMP: ${{ inputs.disable_idempotency_checks || contains(github.event.pull_request.labels.*.name, 'try-runtime:skip-idempotency') }}
+      DISABLE_SPEC: ${{ inputs.disable_spec_version_check || contains(github.event.pull_request.labels.*.name, 'try-runtime:skip-spec-check') }}
+      PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+      RESULT: ${{ needs.try-runtime.result }}
+      TARGET_SHA: ${{ inputs.target_sha || github.event.pull_request.head.sha }}
+    steps:
+      - name: Post result to PR
         uses: actions/github-script@v8
         with:
           script: |
-            const fs = require('fs');
-            const files = fs.readdirSync('out').filter(f => f.endsWith('.md'));
-            let body = `### 🧪 Try Runtime Results (conclusion: **${{ job.status }}**)\n\n`;
-            for (const f of files) {
-              body += `<details><summary>${f}</summary>\n\n` + fs.readFileSync(`out/${f}`, 'utf8') + `\n\n</details>\n`;
-            }
-            await github.issues.createComment({
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              '### 🧪 Try Runtime Results',
+              '',
+              `- PR: #${process.env.PR_NUMBER}`,
+              `- Commit: \`${process.env.TARGET_SHA}\``,
+              `- Disable spec-version check: \`${process.env.DISABLE_SPEC}\``,
+              `- Disable idempotency checks: \`${process.env.DISABLE_IDEMP}\``,
+              `- Conclusion: **${process.env.RESULT}**`,
+              `- [Workflow run](${runUrl})`
+            ].join('\n');
+
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{ github.event.pull_request.number }},
+              issue_number: Number(process.env.PR_NUMBER),
               body
             });
 
       - name: Remove trigger labels
-        if: always()
+        if: always() && github.event_name == 'pull_request'
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.pull_request.number }}
+          number: ${{ env.PR_NUMBER }}
           labels: |
             try-runtime
             try-runtime:skip-spec-check


### PR DESCRIPTION
## Summary

- replace the label handoff with a reusable workflow call
- test an open PR at its head commit and a merged PR at its merge commit
- isolate read-only PR code execution from the write-capable result reporter
- use unique matrix artifact names and post one result comment

## Why

The gate wrote pretty-printed JSON as a single `GITHUB_OUTPUT` value, which caused the reported format error. Compact JSON alone is not sufficient: events created with `GITHUB_TOKEN`, including `pull_request:labeled`, do not start another workflow run. The reusable workflow call removes both failure modes without adding a long-lived token.

GitHub reference: https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs

## Validation

- `actionlint .github/workflows/try-runtime-gate.yml .github/workflows/try-runtime-pr.yml`
- request resolver simulations for open, merged, closed-unmerged, and missing-merge-SHA PRs
- flag resolver simulations for reusable calls and label-triggered runs
- result reporter simulation
- `git diff --check`

## Follow-up

After this PR is merged, add a new `/bot try-runtime` comment to PR #1729. The workflow will select merge commit `bf2ca6f1082cf3d3bc9a91666b507964635f687f`, which is the `v7.0.3` tag target.