### PR TITLE
Fix Try Runtime comment permissions

### DIFF
--- a/.github/workflows/try-runtime-gate.yml
+++ b/.github/workflows/try-runtime-gate.yml
@@ -17,8 +17,7 @@ jobs:
       pr_number: ${{ steps.request.outputs.pr_number }}
       target_sha: ${{ steps.request.outputs.target_sha }}
     permissions:
-      issues: write
-      pull-requests: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Verify requester is trusted
@@ -81,6 +80,7 @@ jobs:
             );
 
       - name: Acknowledge
+        continue-on-error: true
         uses: actions/github-script@v8
         env:
           TARGET_SHA: ${{ steps.request.outputs.target_sha }}
@@ -97,7 +97,7 @@ jobs:
     needs: gate
     permissions:
       contents: read
-      issues: write
+      pull-requests: write
     uses: ./.github/workflows/try-runtime-pr.yml
     with:
       disable_idempotency_checks: ${{ needs.gate.outputs.disable_idempotency_checks == 'true' }}

--- a/.github/workflows/try-runtime-pr.yml
+++ b/.github/workflows/try-runtime-pr.yml
@@ -127,7 +127,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'try-runtime'))
     needs: try-runtime
     permissions:
-      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     env:
       DISABLE_IDEMP: ${{ inputs.disable_idempotency_checks || contains(github.event.pull_request.labels.*.name, 'try-runtime:skip-idempotency') }}


### PR DESCRIPTION
## Summary

- grant PR write permission to the trusted gate and isolated reporter jobs
- keep the executor job read-only
- make the acknowledgement comment best-effort so it cannot block Try Runtime

## Why

The first run after #1730 resolved PR #1729 to the correct merge commit, but the acknowledgement request failed with `403 Resource not accessible by integration`. The job token had `Issues: write` and only `PullRequests: read`. The API response accepted `pull_requests=write` for PR comments.

Failed run: https://github.com/darwinia-network/darwinia/actions/runs/30514080234

## Validation

- `actionlint .github/workflows/try-runtime-gate.yml .github/workflows/try-runtime-pr.yml`
- `git diff --check`

After this PR is merged, a new `/bot try-runtime` comment on #1729 will retry the complete workflow.