### PR TITLE
Fix Try Runtime execution results

### DIFF
--- a/.github/workflows/try-runtime-pr.yml
+++ b/.github/workflows/try-runtime-pr.yml
@@ -46,7 +46,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Crab has no maintained public RPC. Restore its entry when an official endpoint is available.
         runtime:
           - name: darwinia-runtime
             uri: wss://rpc.darwinia.network

--- a/.github/workflows/try-runtime-pr.yml
+++ b/.github/workflows/try-runtime-pr.yml
@@ -103,6 +103,7 @@ jobs:
           output-dir: .
 
       - name: Try Runtime
+        timeout-minutes: 30
         env:
           DISABLE_IDEMP: ${{ steps.flags.outputs.disable_idemp }}
           DISABLE_SPEC: ${{ steps.flags.outputs.disable_spec }}

--- a/.github/workflows/try-runtime-pr.yml
+++ b/.github/workflows/try-runtime-pr.yml
@@ -133,8 +133,35 @@ jobs:
           fi
           args+=(live -u "$TRY_RUNTIME_URI")
 
-          try-runtime "${args[@]}" 2>&1 |
-            tee "out/try-runtime-${RUNTIME_NAME}.log"
+          result_log="out/try-runtime-${RUNTIME_NAME}.log"
+          : > "$result_log"
+          for attempt in 1 2; do
+            attempt_log="out/try-runtime-${RUNTIME_NAME}-attempt-${attempt}.log"
+            set +e
+            try-runtime "${args[@]}" 2>&1 | tee "$attempt_log"
+            pipeline_status=("${PIPESTATUS[@]}")
+            set -e
+
+            status="${pipeline_status[0]}"
+            if [[ "$status" -eq 0 && "${pipeline_status[1]}" -ne 0 ]]; then
+              status="${pipeline_status[1]}"
+            fi
+            {
+              echo "### Attempt ${attempt}"
+              cat "$attempt_log"
+            } >> "$result_log"
+
+            if [[ "$status" -eq 0 ]]; then
+              exit 0
+            fi
+            if [[ "$attempt" -eq 2 ]] ||
+              ! grep -Eq 'status_code: 5[0-9]{2}' "$attempt_log"; then
+              exit "$status"
+            fi
+
+            echo "::warning::Try Runtime received a remote HTTP 5xx response; retrying once."
+            sleep 15
+          done
 
       - name: Collect summary
         if: always()
@@ -200,11 +227,29 @@ jobs:
 
       - name: Remove trigger labels
         if: always() && github.event_name == 'pull_request'
-        uses: actions-ecosystem/action-remove-labels@v1
+        uses: actions/github-script@v8
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ env.PR_NUMBER }}
-          labels: |
-            try-runtime
-            try-runtime:skip-spec-check
-            try-runtime:skip-idempotency
+          script: |
+            const triggerLabels = new Set([
+              'try-runtime',
+              'try-runtime:skip-spec-check',
+              'try-runtime:skip-idempotency'
+            ]);
+            const labels = context.payload.pull_request.labels
+              .map((label) => label.name)
+              .filter((name) => triggerLabels.has(name));
+
+            for (const name of labels) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: Number(process.env.PR_NUMBER),
+                  name
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }

--- a/.github/workflows/try-runtime-pr.yml
+++ b/.github/workflows/try-runtime-pr.yml
@@ -46,6 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Crab has no maintained public RPC. Restore its entry when an official endpoint is available.
         runtime:
           - name: darwinia-runtime
             uri: wss://rpc.darwinia.network
@@ -84,17 +85,56 @@ jobs:
           echo "disable_spec=$spec" >> "$GITHUB_OUTPUT"
           echo "disable_idemp=$idemp" >> "$GITHUB_OUTPUT"
 
-      - name: Try-Runtime
-        id: tr
-        uses: hack-ink/polkadot-runtime-releaser/action/try-runtime@v0.2.0
+      - name: Set up Try Runtime CLI
+        env:
+          TRY_RUNTIME_VERSION: "0.8.0"
+        run: |
+          curl --fail --location --retry 3 \
+            "https://github.com/paritytech/try-runtime-cli/releases/download/v${TRY_RUNTIME_VERSION}/try-runtime-x86_64-unknown-linux-musl" \
+            --output try-runtime
+          chmod +x try-runtime
+          mv try-runtime /usr/local/bin/try-runtime
+
+      - name: Build runtime
+        uses: hack-ink/polkadot-runtime-releaser/action/build@v0.2.0
         with:
           runtime: ${{ matrix.runtime.name }}
           features: try-runtime
           toolchain-ver: 1.82.0
-          try-runtime-ver: 0.8.0
-          disable-spec-version-check: ${{ steps.flags.outputs.disable_spec }}
-          disable-idempotency-checks: ${{ steps.flags.outputs.disable_idemp }}
-          uri: ${{ matrix.runtime.uri }}
+          output-dir: .
+
+      - name: Try Runtime
+        env:
+          DISABLE_IDEMP: ${{ steps.flags.outputs.disable_idemp }}
+          DISABLE_SPEC: ${{ steps.flags.outputs.disable_spec }}
+          RUNTIME_NAME: ${{ matrix.runtime.name }}
+          TRY_RUNTIME_URI: ${{ matrix.runtime.uri }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          runtime_files=(*_runtime-*.compact.compressed.wasm)
+          if [[ ${#runtime_files[@]} -ne 1 ]]; then
+            echo "::error::Expected exactly one runtime Wasm artifact, found ${#runtime_files[@]}."
+            exit 1
+          fi
+
+          mkdir -p out
+          args=(
+            --runtime "${runtime_files[0]}"
+            on-runtime-upgrade
+            --blocktime 6000
+          )
+          if [[ "$DISABLE_SPEC" == "true" ]]; then
+            args+=(--disable-spec-version-check)
+          fi
+          if [[ "$DISABLE_IDEMP" == "true" ]]; then
+            args+=(--disable-idempotency-checks)
+          fi
+          args+=(live -u "$TRY_RUNTIME_URI")
+
+          try-runtime "${args[@]}" 2>&1 |
+            tee "out/try-runtime-${RUNTIME_NAME}.log"
 
       - name: Collect summary
         if: always()
@@ -144,6 +184,7 @@ jobs:
               '',
               `- PR: #${process.env.PR_NUMBER}`,
               `- Commit: \`${process.env.TARGET_SHA}\``,
+              '- Runtime: `darwinia-runtime`',
               `- Disable spec-version check: \`${process.env.DISABLE_SPEC}\``,
               `- Disable idempotency checks: \`${process.env.DISABLE_IDEMP}\``,
               `- Conclusion: **${process.env.RESULT}**`,


### PR DESCRIPTION
## Summary

- Run the Try Runtime CLI directly so its exit code controls the job result.
- Keep the executor at `contents: read`; only the reporter can write PR comments.
- Upload the full Try Runtime log with the summary artifact.
- Retry once only when the CLI log shows a remote HTTP 5xx response.
- Bound the Try Runtime step to 30 minutes.
- Remove trigger labels idempotently with `github-script`.

## Why

Run [30515096851](https://github.com/darwinia-network/darwinia/actions/runs/30515096851) showed that the upstream composite action tried to post a PR comment with the read-only executor token. The same action hides the Try Runtime process exit code with `|| true`, so it cannot act as a correctness gate.

The first validation run of this PR, [30516418963](https://github.com/darwinia-network/darwinia/actions/runs/30516418963), proved that the new workflow preserves a real exit code: the executor failed with 101, the reporter posted `failure`, and the complete log was uploaded. The log identified a transient Cloudflare 525 while reading `chain_getFinalizedHead`, so the follow-up commit adds one bounded retry for remote 5xx responses only. Runtime, migration, idempotency, and decoding failures remain fail-closed.

A later run, [30517335599](https://github.com/darwinia-network/darwinia/actions/runs/30517335599), passed the upgrade, idempotency, and weight checks before its second live-state fetch stopped making progress. A newer commit canceled that run through the workflow concurrency group. The 30-minute step timeout now prevents an unresponsive RPC request from consuming the default six-hour job limit; the always-run summary, artifact, and reporter paths remain active.

## Validation

- `actionlint .github/workflows/try-runtime-pr.yml .github/workflows/try-runtime-gate.yml`
- `git diff --check origin/main...HEAD`
- Pipeline smoke test: success returns 0; a simulated exit 23 returns 23 through `tee`.
- Retry smoke test: 525 then success returns 0; a non-network exit 23 is not retried.
- Independent workflow reviews: no actionable findings, including timeout and post-failure behavior.
- Live failure and cancellation paths: reporter and full attempt artifact confirmed.

## After merge

Post `/bot try-runtime` on #1729 again. The workflow must check out `bf2ca6f1082cf3d3bc9a91666b507964635f687f`, run Darwinia, and report the real result.